### PR TITLE
chore(devcontainer): wrap class script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
         "chris-noring.cpp-snippets",
         "samubarb.vscode-doxyfile",
         "Gruntfuggly.todo-tree",
-        "wayou.vscode-todo-highlight"
+        "wayou.vscode-todo-highlight",
+        "augustocdias.tasks-shell-input"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh",

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ template
 
 log
 webserv
-.vscode
+.vscode/*
 tmp
 build
+
+# Finder is a dipstick
+**/.DS_Store
+
+# we need .vscode/tasks to run createClass.sh from the command bar
+!.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,7 @@
         {
             "id": "className",
             "type": "promptString",
-            "description": "Enter the class's name",
+            "description": "Enter the class name",
             "default": "BaseClass"
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "tasks": [
+        {
+            "label": "Create a class",
+            "type": "shell",
+            "command": "${workspaceFolder}/scripts/createClass.sh",
+            "args": [
+                "${input:classDir}",
+                "${input:className}"
+            ],
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "classDir",
+            "type": "promptString",
+            "description": "Enter the target directory",
+            "default": ""
+        },
+        {
+            "id": "className",
+            "type": "promptString",
+            "description": "Enter the class's name",
+            "default": "BaseClass"
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
     zsh \
     g++ \
     make \
@@ -40,4 +40,6 @@ RUN pip install pre-commit
 WORKDIR /workspace
 COPY . /workspace
 
-CMD pre-commit install && pre-commit install --hook-type commit-msg && zsh
+RUN pre-commit install && pre-commit install --hook-type commit-msg
+
+ENTRYPOINT [ "zsh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ COPY . /workspace
 
 RUN pre-commit install && pre-commit install --hook-type commit-msg
 
-ENTRYPOINT [ "zsh" ]
+CMD [ "zsh" ]

--- a/docs/contributing/getting_started.md
+++ b/docs/contributing/getting_started.md
@@ -38,6 +38,11 @@ This will:
 - Create a `.cpp` file in `src/<subfolder>/`
 - Generate a class with default constructor, destructor, copy constructor, copy assignment operator, and Doxygen documentation
 
+#### Quickly run this script from within VS Code:
+1. Press `Cmd + P` (or `Ctrl + P` on Windows/Linux)
+2. Select `Tasks: Run Task`
+3. Run `Create a class`
+
 ## Conventions
 
 ### Naming Conventions


### PR DESCRIPTION
### Description

This PR adds a shortcut for the createClass script, accessible via VSCode's command bar, using the "Tasks Shell Input" extension.
Additionally, it modifies the Dockerfile to run an initial `apt-get upgrade`, install commit hooks while building, and run `zsh` in exec form to avoid unexpected behaviour.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

### How to Test

If using VSCode, open your command bar (ctrl-shift-P by default). Look for "Tasks: Run Task", select it, then select "Create a class", which should first prompt for the target directory, then for the class's name.

### Checklist

- [x] Code follows project style guidelines
- [ ] Documentation has been updated