### PR TITLE
refactor: ErrorMessages singleton

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,12 +20,12 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
 DerivePointerAlignment: false
-PointerAlignment: Right
-ReferenceAlignment: Right
+PointerAlignment: Left
+ReferenceAlignment: Left
 AccessModifierOffset: 0
 # RemoveParentheses: ReturnStatement # wrong version
 SpaceBeforeParens: ControlStatementsExceptControlMacros
-EmptyLineBeforeAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
 EmptyLineAfterAccessModifier: Never
 # InsertNewlineAtEOF: true # wrong version
 BinPackParameters: false

--- a/config/configfile_example
+++ b/config/configfile_example
@@ -1,6 +1,6 @@
 server
 {
-	listen 127.0.0.1:80;  # Choose the port
+	listen 127.0.0.1:8080;  # Choose the port
 	server_name example.com;  # Setup server names
 
 	# Default error pages

--- a/include/config/Parser.hpp
+++ b/include/config/Parser.hpp
@@ -69,7 +69,7 @@ namespace config {
 			ConfigFileParser();
 			~ConfigFileParser();
 
-			int loadConfigFile(std::string &configFileName);
+			int loadConfigFile(std::string& configFileName);
 
 			int getIsLoaded() const;
 			t_config_data getConfigData() const;
@@ -79,42 +79,43 @@ namespace config {
 			std::vector<std::string> getServerNames(int index) const;
 			std::map<int, std::string> getErrorPages(int index) const;
 			unsigned long getMaxBodySize(int index) const;
-			t_server *getServer(int index);
+			t_server* getServer(int index);
 
 			void printConfigData(int detailed);
-			int testFunction(const std::string &key, std::vector<std::string> &args, int &lineCount);
+			int testFunction(const std::string& key, std::vector<std::string>& args, int& lineCount);
+
 		private:
-			ConfigFileParser(const ConfigFileParser &other);
-			ConfigFileParser &operator=(const ConfigFileParser &other);
+			ConfigFileParser(const ConfigFileParser& other);
+			ConfigFileParser& operator=(const ConfigFileParser& other);
 			t_config_data m_configData;
 			int m_isLoaded;
 
-			int readConfigFile(std::string &configFileName, std::string &file);
-			int parseConfigFile(std::string &configFileName, int layer, unsigned long &i, int &lineCount);
+			int readConfigFile(std::string& configFileName, std::string& file);
+			int parseConfigFile(std::string& configFileName, int layer, unsigned long& i, int& lineCount);
 
-			int handleServer(std::string &line, unsigned long *i);
-			int handlePrompt(std::string &line, int layer, int &lineCount);
-			int SaveConfigData(std::vector<std::string> &args, int layer, int qoute_flag, int &lineCount);
-			enum CmdId idCommand(const std::string &command);
+			int handleServer(std::string& line, unsigned long* i);
+			int handlePrompt(std::string& line, int layer, int& lineCount);
+			int SaveConfigData(std::vector<std::string>& args, int layer, int qoute_flag, int& lineCount);
+			enum CmdId idCommand(const std::string& command);
 
-			int server(std::vector<std::string> &args, int &lineCount, int layer);
-			int location(std::vector<std::string> &args, const int &lineCount, int layer);
+			int server(std::vector<std::string>& args, int& lineCount, int layer);
+			int location(std::vector<std::string>& args, const int& lineCount, int layer);
 
-			int listen(std::vector<std::string> &args, int &lineCount, int layer);
-			int serverName(std::vector<std::string> &args, int &lineCount, int layer);
-			int errorPage(std::vector<std::string> &args, int &lineCount, int layer);
-			int clientMaxBodySize(std::vector<std::string> &args, int &lineCount, int layer);
-			int limitExcept(std::vector<std::string> &args, int &lineCount, int layer);
-			int returnKeyword(std::vector<std::string> &args, const int &lineCount, int layer);
-			int root(std::vector<std::string> &args, int &lineCount, int layer);
-			int autoindex(std::vector<std::string> &args, int &lineCount, int layer);
-			int index(std::vector<std::string> &args, int &lineCount, int layer);
+			int listen(std::vector<std::string>& args, int& lineCount, int layer);
+			int serverName(std::vector<std::string>& args, int& lineCount, int layer);
+			int errorPage(std::vector<std::string>& args, int& lineCount, int layer);
+			int clientMaxBodySize(std::vector<std::string>& args, int& lineCount, int layer);
+			int limitExcept(std::vector<std::string>& args, int& lineCount, int layer);
+			int returnKeyword(std::vector<std::string>& args, const int& lineCount, int layer);
+			int root(std::vector<std::string>& args, int& lineCount, int layer);
+			int autoindex(std::vector<std::string>& args, int& lineCount, int layer);
+			int index(std::vector<std::string>& args, int& lineCount, int layer);
 
-			void printLocations(const std::vector<config::t_location> &locations,
+			void printLocations(const std::vector<config::t_location>& locations,
 								int layer,
 								int detailed,
 								std::vector<int> layer_num);
-			config::t_location *getLocation(int layer);
+			config::t_location* getLocation(int layer);
 	};
 
 } // namespace config

--- a/include/core/AHandler.hpp
+++ b/include/core/AHandler.hpp
@@ -13,11 +13,11 @@ namespace core {
 	};
 
 	struct HandlerContext {
-			http::VirtualServer &vServer;
-			http::Connection &conn;
+			http::VirtualServer& vServer;
+			http::Connection& conn;
 			uint32_t events;
 
-			HandlerContext(http::VirtualServer &vServer, http::Connection &conn)
+			HandlerContext(http::VirtualServer& vServer, http::Connection& conn)
 				: vServer(vServer)
 				, conn(conn)
 				, events(EPOLLIN) {}
@@ -28,7 +28,7 @@ namespace core {
 			AHandler()
 				: m_state(PENDING) {}
 
-			virtual void handle(HandlerContext &ctx) = 0;
+			virtual void handle(HandlerContext& ctx) = 0;
 
 			virtual bool hasCompleted() const {
 				return m_state == COMPLETED;
@@ -39,6 +39,7 @@ namespace core {
 			}
 
 			virtual ~AHandler() {}
+
 		protected:
 			HandlerState m_state;
 	};

--- a/include/core/IOHandler.hpp
+++ b/include/core/IOHandler.hpp
@@ -14,11 +14,12 @@ namespace core {
 		public:
 			IOHandler();
 			~IOHandler();
-			IOHandler(const IOHandler &other);
-			IOHandler &operator=(const IOHandler &rhs);
+			IOHandler(const IOHandler& other);
+			IOHandler& operator=(const IOHandler& rhs);
 
-			void handle(HandlerContext &ctx);
+			void handle(HandlerContext& ctx);
 			bool hasCompleted() const;
+
 		private:
 			RequestHandler m_requestHandler;
 			ResponseHandler m_responseHandler;

--- a/include/core/Reactor.hpp
+++ b/include/core/Reactor.hpp
@@ -14,10 +14,10 @@
 namespace core {
 
 	struct EventData {
-			AHandler *handler;
+			AHandler* handler;
 			HandlerContext ctx;
 
-			EventData(AHandler *handler, const HandlerContext &ctx)
+			EventData(AHandler* handler, const HandlerContext& ctx)
 				: handler(handler)
 				, ctx(ctx) {}
 	};
@@ -33,24 +33,25 @@ namespace core {
 
 			void init() throw(std::exception);
 			int getEpollFd() const;
-			const std::vector<http::VirtualServer> &getVirtualServers() const;
-			std::vector<http::VirtualServer> &getVirtualServers();
+			const std::vector<http::VirtualServer>& getVirtualServers() const;
+			std::vector<http::VirtualServer>& getVirtualServers();
 
-			void addVirtualServer(config::t_server &serverConfig) throw(
+			void addVirtualServer(config::t_server& serverConfig) throw(
 				std::exception);
 			bool removeVirtualServer(std::vector<http::VirtualServer>::iterator it);
-			bool addVirtualServers(config::t_config_data &configData);
+			bool addVirtualServers(config::t_config_data& configData);
 
 			void react();
-		private:
-			Reactor(const Reactor &other);
-			Reactor &operator=(const Reactor &other);
 
-			void registerHandler(int fd, AHandler *handler, const HandlerContext &ctx, uint32_t events = EPOLLIN);
+		private:
+			Reactor(const Reactor& other);
+			Reactor& operator=(const Reactor& other);
+
+			void registerHandler(int fd, AHandler* handler, const HandlerContext& ctx, uint32_t events = EPOLLIN);
 			void unregisterHandler(int fd) throw(std::runtime_error);
 
 			void acceptNewConnections();
-			void handleEvents(t_event *events, int nEvents);
+			void handleEvents(t_event* events, int nEvents);
 
 			int m_epoll_master_fd;
 			std::vector<http::VirtualServer> m_vServers;

--- a/include/core/RequestHandler.hpp
+++ b/include/core/RequestHandler.hpp
@@ -13,10 +13,11 @@ namespace core {
 			RequestHandler();
 			~RequestHandler();
 
-			void handle(HandlerContext &ctx);
+			void handle(HandlerContext& ctx);
+
 		private:
-			RequestHandler(const RequestHandler &other);
-			RequestHandler &operator=(const RequestHandler &rhs);
+			RequestHandler(const RequestHandler& other);
+			RequestHandler& operator=(const RequestHandler& rhs);
 	};
 
 } /* namespace core */

--- a/include/core/ResponseHandler.hpp
+++ b/include/core/ResponseHandler.hpp
@@ -13,10 +13,11 @@ namespace core {
 			ResponseHandler();
 			~ResponseHandler();
 
-			void handle(HandlerContext &ctx);
+			void handle(HandlerContext& ctx);
+
 		private:
-			ResponseHandler(const ResponseHandler &other);
-			ResponseHandler &operator=(const ResponseHandler &rhs);
+			ResponseHandler(const ResponseHandler& other);
+			ResponseHandler& operator=(const ResponseHandler& rhs);
 	};
 
 } /* namespace core */

--- a/include/http/ClientSocket.hpp
+++ b/include/http/ClientSocket.hpp
@@ -21,9 +21,9 @@ namespace http {
 			ClientSocket(void);
 			ClientSocket(int listen_socket) throw(std::exception);
 			~ClientSocket(void);
-			ClientSocket(const ClientSocket &other);
-			ClientSocket &operator=(const ClientSocket &rhs);
-			bool operator==(const ClientSocket &other) const;
+			ClientSocket(const ClientSocket& other);
+			ClientSocket& operator=(const ClientSocket& rhs);
+			bool operator==(const ClientSocket& other) const;
 
 			void accept(int listen_socket) throw(std::runtime_error);
 
@@ -33,6 +33,7 @@ namespace http {
 			unsigned int getSocketSize(void) const;
 			bool isAlive(void) const;
 			void close(void);
+
 		private:
 			int m_fd;
 			t_sockaddr m_socketAddress;

--- a/include/http/Connection.hpp
+++ b/include/http/Connection.hpp
@@ -14,16 +14,17 @@ namespace http {
 			Connection();
 			Connection(int listen_socket) throw(std::exception);
 			~Connection();
-			Connection(const Connection &other);
-			Connection &operator=(const Connection &rhs);
+			Connection(const Connection& other);
+			Connection& operator=(const Connection& rhs);
 
-			const ClientSocket &getSocket(void) const;
-			ClientSocket &getSocket(void);
-			const http::Request &getRequest(void) const;
-			http::Request &getRequest(void);
+			const ClientSocket& getSocket(void) const;
+			ClientSocket& getSocket(void);
+			const http::Request& getRequest(void) const;
+			http::Request& getRequest(void);
 			void close(void);
 
-			bool operator==(const Connection &other) const;
+			bool operator==(const Connection& other) const;
+
 		private:
 			ClientSocket m_client_socket;
 			http::Request m_request;

--- a/include/http/ErrorMessages.hpp
+++ b/include/http/ErrorMessages.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "shared/defines.hpp"
+
+#include <map>
+#include <string>
+
+namespace http {
+
+	typedef std::pair<http::StatusCode, std::string> t_errorMessage;
+	typedef std::map<t_errorMessage::first_type, t_errorMessage::second_type> t_errorMessages;
+
+	/**
+	 * @class ErrorMessages
+	 * @brief Singleton class to store and retrieve error messages
+	 */
+	class ErrorMessages {
+		public:
+			~ErrorMessages();
+
+			static const ErrorMessages &getInstance() {
+				static ErrorMessages instance;
+				return instance;
+			}
+
+			// singleton is otherwise lazily initialized
+			static void eagerInit() {
+				(void)getInstance();
+			}
+
+			const t_errorMessages &getErrorMessages() const {
+				return m_errorMessages;
+			}
+		private:
+			ErrorMessages() {
+				m_errorMessages[BAD_REQUEST] = "Bad Request";
+				m_errorMessages[UNAUTHORIZED] = "Unauthorized";
+				m_errorMessages[FORBIDDEN] = "Forbidden";
+				m_errorMessages[NOT_FOUND] = "Not Found";
+				m_errorMessages[METHOD_NOT_ALLOWED] = "Method Not Allowed";
+				m_errorMessages[NOT_ACCEPTABLE] = "Not Acceptable";
+				m_errorMessages[REQUEST_TIMEOUT] = "Request Timeout";
+				m_errorMessages[CONFLICT] = "Conflict";
+				m_errorMessages[GONE] = "Gone";
+				m_errorMessages[LENGTH_REQUIRED] = "Length Required";
+				m_errorMessages[PAYLOAD_TOO_LARGE] = "Payload Too Large";
+				m_errorMessages[URI_TOO_LONG] = "URI Too Long";
+				m_errorMessages[UNSUPPORTED_MEDIA_TYPE] = "Unsupported Media Type";
+				m_errorMessages[RANGE_NOT_SATISFIABLE] = "Range Not Satisfiable";
+				m_errorMessages[EXPECTATION_FAILED] = "Expectation Failed";
+				m_errorMessages[IM_A_TEAPOT] = "I'm a teapot";
+				m_errorMessages[MISDIRECTED_REQUEST] = "Misdirected Request";
+				m_errorMessages[UPGRADE_REQUIRED] = "Upgrade Required";
+				m_errorMessages[INTERNAL_SERVER_ERROR] = "Internal Server Error";
+				m_errorMessages[NOT_IMPLEMENTED] = "Not Implemented";
+				m_errorMessages[BAD_GATEWAY] = "Bad Gateway";
+				m_errorMessages[SERVICE_UNAVAILABLE] = "Service Unavailable";
+				m_errorMessages[GATEWAY_TIMEOUT] = "Gateway Timeout";
+				m_errorMessages[HTTP_VERSION_NOT_SUPPORTED] = "HTTP Version Not Supported";
+			}
+
+			ErrorMessages(const ErrorMessages &other);
+			ErrorMessages &operator=(const ErrorMessages &rhs);
+
+			t_errorMessages m_errorMessages;
+	};
+
+} /* namespace http */

--- a/include/http/ErrorMessages.hpp
+++ b/include/http/ErrorMessages.hpp
@@ -18,7 +18,7 @@ namespace http {
 		public:
 			~ErrorMessages();
 
-			static const ErrorMessages &getInstance() {
+			static const ErrorMessages& getInstance() {
 				static ErrorMessages instance;
 				return instance;
 			}
@@ -28,11 +28,12 @@ namespace http {
 				(void)getInstance();
 			}
 
-			const t_errorMessages &getErrorMessages() const;
+			const t_errorMessages& getErrorMessages() const;
+
 		private:
 			ErrorMessages();
-			ErrorMessages(const ErrorMessages &other);
-			ErrorMessages &operator=(const ErrorMessages &rhs);
+			ErrorMessages(const ErrorMessages& other);
+			ErrorMessages& operator=(const ErrorMessages& rhs);
 
 			t_errorMessages m_errorMessages;
 	};

--- a/include/http/ErrorMessages.hpp
+++ b/include/http/ErrorMessages.hpp
@@ -28,37 +28,9 @@ namespace http {
 				(void)getInstance();
 			}
 
-			const t_errorMessages &getErrorMessages() const {
-				return m_errorMessages;
-			}
+			const t_errorMessages &getErrorMessages() const;
 		private:
-			ErrorMessages() {
-				m_errorMessages[BAD_REQUEST] = "Bad Request";
-				m_errorMessages[UNAUTHORIZED] = "Unauthorized";
-				m_errorMessages[FORBIDDEN] = "Forbidden";
-				m_errorMessages[NOT_FOUND] = "Not Found";
-				m_errorMessages[METHOD_NOT_ALLOWED] = "Method Not Allowed";
-				m_errorMessages[NOT_ACCEPTABLE] = "Not Acceptable";
-				m_errorMessages[REQUEST_TIMEOUT] = "Request Timeout";
-				m_errorMessages[CONFLICT] = "Conflict";
-				m_errorMessages[GONE] = "Gone";
-				m_errorMessages[LENGTH_REQUIRED] = "Length Required";
-				m_errorMessages[PAYLOAD_TOO_LARGE] = "Payload Too Large";
-				m_errorMessages[URI_TOO_LONG] = "URI Too Long";
-				m_errorMessages[UNSUPPORTED_MEDIA_TYPE] = "Unsupported Media Type";
-				m_errorMessages[RANGE_NOT_SATISFIABLE] = "Range Not Satisfiable";
-				m_errorMessages[EXPECTATION_FAILED] = "Expectation Failed";
-				m_errorMessages[IM_A_TEAPOT] = "I'm a teapot";
-				m_errorMessages[MISDIRECTED_REQUEST] = "Misdirected Request";
-				m_errorMessages[UPGRADE_REQUIRED] = "Upgrade Required";
-				m_errorMessages[INTERNAL_SERVER_ERROR] = "Internal Server Error";
-				m_errorMessages[NOT_IMPLEMENTED] = "Not Implemented";
-				m_errorMessages[BAD_GATEWAY] = "Bad Gateway";
-				m_errorMessages[SERVICE_UNAVAILABLE] = "Service Unavailable";
-				m_errorMessages[GATEWAY_TIMEOUT] = "Gateway Timeout";
-				m_errorMessages[HTTP_VERSION_NOT_SUPPORTED] = "HTTP Version Not Supported";
-			}
-
+			ErrorMessages();
 			ErrorMessages(const ErrorMessages &other);
 			ErrorMessages &operator=(const ErrorMessages &rhs);
 

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -17,13 +17,14 @@ namespace http {
 		public:
 			Request();
 			~Request();
-			Request(const Request &other);
-			Request &operator=(const Request &rhs);
+			Request(const Request& other);
+			Request& operator=(const Request& rhs);
 
 			uint32_t getReceivedBytes(void) const;
-			const std::string &getData(void) const;
-			const std::string &getHead(void) const;
-			const std::string &getBody(void) const;
+			const std::string& getData(void) const;
+			const std::string& getHead(void) const;
+			const std::string& getBody(void) const;
+
 		private:
 			char m_read_buffer[BUFFER_SIZE];
 			uint32_t m_received_bytes;

--- a/include/http/ServerSocket.hpp
+++ b/include/http/ServerSocket.hpp
@@ -26,8 +26,8 @@ namespace http {
 			ServerSocket();
 			ServerSocket(int port, uint32_t ip = LOCALHOST_ADDRESS);
 			~ServerSocket();
-			ServerSocket(const ServerSocket &other);
-			ServerSocket &operator=(const ServerSocket &other);
+			ServerSocket(const ServerSocket& other);
+			ServerSocket& operator=(const ServerSocket& other);
 
 			bool init();
 			bool create();
@@ -44,6 +44,7 @@ namespace http {
 			bool isOpen() const;
 			bool isBound() const;
 			bool isListening() const;
+
 		private:
 			int m_fd;
 			uint32_t m_ip;

--- a/include/http/VirtualServer.hpp
+++ b/include/http/VirtualServer.hpp
@@ -23,24 +23,25 @@ namespace http {
 	class VirtualServer {
 		public:
 			VirtualServer();
-			VirtualServer(config::t_server &serverConfig);
+			VirtualServer(config::t_server& serverConfig);
 			~VirtualServer();
-			VirtualServer(const VirtualServer &other);
-			VirtualServer &operator=(const VirtualServer &other);
+			VirtualServer(const VirtualServer& other);
+			VirtualServer& operator=(const VirtualServer& other);
 
-			const std::vector<std::string> &getNames(void) const;
-			const std::map<int, std::string> &getErrorPages(void) const;
-			const std::vector<config::t_location> &getLocations(void) const;
+			const std::vector<std::string>& getNames(void) const;
+			const std::map<int, std::string>& getErrorPages(void) const;
+			const std::vector<config::t_location>& getLocations(void) const;
 			uint64_t getMaxBodySize(void) const;
-			const ServerSocket &getSocket(void) const;
-			ServerSocket &getSocket(void);
-			const t_connections &getConnections(void) const;
-			t_connections &getConnections(void);
+			const ServerSocket& getSocket(void) const;
+			ServerSocket& getSocket(void);
+			const t_connections& getConnections(void) const;
+			t_connections& getConnections(void);
 
 			bool addConnection(void);
-			bool removeConnection(Connection &connection);
+			bool removeConnection(Connection& connection);
 
 			bool listen(void);
+
 		private:
 			uint64_t m_client_max_body_size;
 			std::vector<std::string> m_names;

--- a/include/http/createResponse.hpp
+++ b/include/http/createResponse.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "http/ErrorMessages.hpp"
+
+#include <string>
+
+namespace http {
+
+	const std::string createResponse(StatusCode status_code);
+	const std::string status(StatusCode status_code);
+
+} // namespace http

--- a/include/shared/stringUtils.hpp
+++ b/include/shared/stringUtils.hpp
@@ -11,9 +11,9 @@ namespace shared {
 
 		const std::string WHITESPACES = " \t\n\v\f\r";
 
-		void split(const std::string &str, std::vector<std::string> &result, const std::string &delimiters = WHITESPACES);
+		void split(const std::string& str, std::vector<std::string>& result, const std::string& delimiters = WHITESPACES);
 
-		void trim(std::string &str, const std::string &delimiters = WHITESPACES);
+		void trim(std::string& str, const std::string& delimiters = WHITESPACES);
 
 	} // namespace string
 

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -19,7 +19,7 @@ namespace config {
 	 * @brief Copy constructor.
 	 * @param other The other ConfigFileParser object to copy.
 	 */
-	ConfigFileParser::ConfigFileParser(const ConfigFileParser &) {
+	ConfigFileParser::ConfigFileParser(const ConfigFileParser&) {
 		m_isLoaded = 0;
 	}
 
@@ -28,7 +28,7 @@ namespace config {
 	 * @param other The other ConfigFileParser object to assign from.
 	 * @return A reference to the assigned ConfigFileParser object.
 	 */
-	ConfigFileParser &ConfigFileParser::operator=(const ConfigFileParser &) {
+	ConfigFileParser& ConfigFileParser::operator=(const ConfigFileParser&) {
 		m_isLoaded = 0;
 		return *this;
 	}
@@ -38,8 +38,8 @@ namespace config {
 	 * @param configFileName The name of the configuration file.
 	 * @param line the location where the configuration file is stored by the read.
 	 */
-	int ConfigFileParser::readConfigFile(std::string &configFileName,
-										 std::string &line) {
+	int ConfigFileParser::readConfigFile(std::string& configFileName,
+										 std::string& line) {
 		if (configFileName.empty()) {
 			LOG("Configuration file name is empty." << std::endl, 1)
 			return 1;
@@ -87,7 +87,7 @@ namespace config {
 	 * @param lineCount The current line number.
 	 * @return 0 if successful, 1 if error.
 	 */
-	int ConfigFileParser::parseConfigFile(std::string &str, int layer, unsigned long &i, int &lineCount) {
+	int ConfigFileParser::parseConfigFile(std::string& str, int layer, unsigned long& i, int& lineCount) {
 		std::string line;
 		int findQuotesFlag = 0;
 		for (; i < str.size(); i++) {
@@ -183,7 +183,7 @@ namespace config {
 	 * @param configFileName The name of the configuration file.
 	 * @return 0 if successful, 1 if error.
 	 */
-	int ConfigFileParser::loadConfigFile(std::string &configFileName) {
+	int ConfigFileParser::loadConfigFile(std::string& configFileName) {
 		std::string file;
 		readConfigFile(configFileName, file);
 		if (file.empty()) {
@@ -238,7 +238,7 @@ namespace config {
 		return m_configData.servers[index].max_body_size;
 	}
 
-	t_server *ConfigFileParser::getServer(int index) {
+	t_server* ConfigFileParser::getServer(int index) {
 		return &m_configData.servers[index];
 	}
 

--- a/src/config/Parser_helpers.cpp
+++ b/src/config/Parser_helpers.cpp
@@ -10,7 +10,7 @@ namespace config {
 	 * @param lineCount the current line number.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::handlePrompt(std::string &line, int layer, int &lineCount) {
+	int ConfigFileParser::handlePrompt(std::string& line, int layer, int& lineCount) {
 		// return 0 if successful and semicolon is found, 1 if semicolon is not
 		// found, 2 if error cut off trailing and starting spaces
 		int qouteFlag = 1;
@@ -49,8 +49,8 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return struct location* the current location.
 	 */
-	t_location *ConfigFileParser::getLocation(int layer) {
-		config::t_location *temp = &m_configData.servers.back().locations.back();
+	t_location* ConfigFileParser::getLocation(int layer) {
+		config::t_location* temp = &m_configData.servers.back().locations.back();
 		for (int i = 2; i < layer; i++) {
 			temp = &temp->locations.back();
 		}
@@ -108,7 +108,7 @@ namespace config {
 	 * @param layer_num the current layer number.
 	 */
 	void ConfigFileParser::printLocations(
-		const std::vector<config::t_location> &locations, int layer, int detailed, std::vector<int> layer_num) {
+		const std::vector<config::t_location>& locations, int layer, int detailed, std::vector<int> layer_num) {
 		std::string c = "";
 		for (int i = 0; i < layer; i++) {
 			c += "   ";
@@ -156,9 +156,9 @@ namespace config {
 		}
 	}
 
-	int ConfigFileParser::testFunction(const std::string &key,
-									   std::vector<std::string> &args,
-									   int &lineCount) {
+	int ConfigFileParser::testFunction(const std::string& key,
+									   std::vector<std::string>& args,
+									   int& lineCount) {
 		int i;
 		if (key == "server")
 			i = server(args, lineCount, 0);
@@ -195,7 +195,7 @@ namespace config {
 	 * error_page, 4 if client_max_body_size, 5 if location, 6 if limit_exept, 7 if
 	 * return, 8 if root, 9 if autoindex, 10 if index, 404 if not found.)
 	 */
-	enum CmdId ConfigFileParser::idCommand(const std::string &key) {
+	enum CmdId ConfigFileParser::idCommand(const std::string& key) {
 		if (key == "server")
 			return SERVER_ID;
 		else if (key == "listen")
@@ -231,7 +231,7 @@ namespace config {
 	 * @param lineCount The current line number.
 	 * @return 0 if successful, 1 if error.
 	 */
-	int ConfigFileParser::SaveConfigData(std::vector<std::string> &args, int layer, int qoute_flag, int &lineCount) {
+	int ConfigFileParser::SaveConfigData(std::vector<std::string>& args, int layer, int qoute_flag, int& lineCount) {
 		enum CmdId command_id = idCommand(args[0]);
 		if (command_id == UNKNOWN_ID) {
 			LOG("Configuration file (line " << lineCount << "): "

--- a/src/config/Parser_keywords.cpp
+++ b/src/config/Parser_keywords.cpp
@@ -30,7 +30,7 @@ namespace config {
 	 * @param str The string to check.
 	 * @return true if the string is a number, false otherwise.
 	 */
-	bool is_number(const std::string &str) {
+	bool is_number(const std::string& str) {
 		std::string::const_iterator it = str.begin();
 		while (it != str.end() && std::isdigit(*it))
 			++it;
@@ -48,7 +48,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::server(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::server(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 		if (args.size() != 1) {
 			LOG("Configuration file (line "
@@ -76,8 +76,8 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::location(std::vector<std::string> &args,
-								   const int &lineCount,
+	int ConfigFileParser::location(std::vector<std::string>& args,
+								   const int& lineCount,
 								   int layer) {
 		if (args.size() != 2) {
 			LOG("Configuration file (line "
@@ -104,7 +104,7 @@ namespace config {
 			m_configData.servers.back().locations.push_back(new_location);
 			return 0;
 		}
-		t_location *temp = &m_configData.servers.back().locations.back();
+		t_location* temp = &m_configData.servers.back().locations.back();
 		for (int i = 2; i < layer; i++) {
 			temp = &temp->locations.back();
 		}
@@ -120,7 +120,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::listen(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::listen(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 		if (args.size() != 2) {
 			LOG("Configuration file (line "
@@ -201,7 +201,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::serverName(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::serverName(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 		if (args.size() < 2) {
 			LOG("Configuration file (line "
@@ -238,7 +238,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::errorPage(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::errorPage(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 		if (args.size() < 3 || args.size() > 1001) {
 			LOG("Configuration file (line "
@@ -279,8 +279,8 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::clientMaxBodySize(std::vector<std::string> &args,
-											int &lineCount,
+	int ConfigFileParser::clientMaxBodySize(std::vector<std::string>& args,
+											int& lineCount,
 											int layer) {
 		(void)layer;
 		if (args.size() != 2) {
@@ -311,8 +311,8 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::limitExcept(std::vector<std::string> &args,
-									  int &lineCount,
+	int ConfigFileParser::limitExcept(std::vector<std::string>& args,
+									  int& lineCount,
 									  int layer) {
 		(void)layer;
 		if (args.size() < 2 || args.size() > 15) {
@@ -351,7 +351,7 @@ namespace config {
 				1);
 			return 1;
 		}
-		t_location *current = getLocation(layer);
+		t_location* current = getLocation(layer);
 		current->methods = allowed_methods;
 		return 0;
 	}
@@ -364,8 +364,8 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::returnKeyword(std::vector<std::string> &args,
-										const int &lineCount,
+	int ConfigFileParser::returnKeyword(std::vector<std::string>& args,
+										const int& lineCount,
 										int layer) {
 		if (args.size() != 2) {
 			LOG("Configuration file (line "
@@ -382,7 +382,7 @@ namespace config {
 			return 1;
 		}
 		// TODO: check if valid url?
-		t_location *current = getLocation(layer);
+		t_location* current = getLocation(layer);
 		current->return_url = args[1];
 		return 0;
 	}
@@ -395,7 +395,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::root(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::root(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 		if (args.size() != 2) {
 			LOG("Configuration file (line "
@@ -411,7 +411,7 @@ namespace config {
 			return 1;
 		}
 		// TODO: check if path is valid
-		t_location *current = getLocation(layer);
+		t_location* current = getLocation(layer);
 		current->root = args[1];
 		return 0;
 	}
@@ -424,7 +424,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::autoindex(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::autoindex(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 		if (args.size() != 2) {
 			LOG("Configuration file (line "
@@ -433,7 +433,7 @@ namespace config {
 				1);
 			return 1;
 		}
-		t_location *current = getLocation(layer);
+		t_location* current = getLocation(layer);
 		if (args[1] == "on") {
 			current->autoindex = true;
 		} else if (args[1] == "off") {
@@ -456,7 +456,7 @@ namespace config {
 	 * @param layer the current layer of the configuration file.
 	 * @return int 0 if successful, 1 if not.
 	 */
-	int ConfigFileParser::index(std::vector<std::string> &args, int &lineCount, int layer) {
+	int ConfigFileParser::index(std::vector<std::string>& args, int& lineCount, int layer) {
 		(void)layer;
 
 		if (args.size() < 2 || args.size() > 1001) {
@@ -466,7 +466,7 @@ namespace config {
 				1);
 			return 1;
 		}
-		t_location *current = getLocation(layer);
+		t_location* current = getLocation(layer);
 		current->index.clear();
 		for (unsigned long i = 1; i < args.size(); i++) {
 			if (args[i].length() > 1000 || args[i].length() == 0) {

--- a/src/core/IOHandler.cpp
+++ b/src/core/IOHandler.cpp
@@ -18,7 +18,7 @@ namespace core {
 	 * @brief Copy constructor.
 	 * @param other The other IOHandler object to copy.
 	 */
-	IOHandler::IOHandler(const IOHandler &) {
+	IOHandler::IOHandler(const IOHandler&) {
 	}
 
 	/**
@@ -26,11 +26,11 @@ namespace core {
 	 * @param other The other IOHandler object to assign from.
 	 * @return A reference to the assigned IOHandler object.
 	 */
-	IOHandler &IOHandler::operator=(const IOHandler &) {
+	IOHandler& IOHandler::operator=(const IOHandler&) {
 		return *this;
 	}
 
-	void IOHandler::handle(HandlerContext &ctx) {
+	void IOHandler::handle(HandlerContext& ctx) {
 		if (ctx.events & EPOLLIN) {
 			m_requestHandler.handle(ctx);
 		}

--- a/src/core/Reactor.cpp
+++ b/src/core/Reactor.cpp
@@ -40,7 +40,7 @@ namespace core {
 	 * @brief Copy constructor.
 	 * @param other The other Reactor object to copy.
 	 */
-	Reactor::Reactor(const Reactor &other)
+	Reactor::Reactor(const Reactor& other)
 		: m_epoll_master_fd(other.getEpollFd())
 		, m_vServers(other.getVirtualServers()) {
 	}
@@ -50,7 +50,7 @@ namespace core {
 	 * @param other The other Reactor object to assign from.
 	 * @return A reference to the assigned Reactor object.
 	 */
-	Reactor &Reactor::operator=(const Reactor &rhs) {
+	Reactor& Reactor::operator=(const Reactor& rhs) {
 		if (this == &rhs)
 			return *this;
 		m_epoll_master_fd = rhs.getEpollFd();
@@ -68,15 +68,15 @@ namespace core {
 			throw std::exception();
 	}
 
-	const std::vector<http::VirtualServer> &Reactor::getVirtualServers(void) const {
+	const std::vector<http::VirtualServer>& Reactor::getVirtualServers(void) const {
 		return m_vServers;
 	}
 
-	std::vector<http::VirtualServer> &Reactor::getVirtualServers(void) {
+	std::vector<http::VirtualServer>& Reactor::getVirtualServers(void) {
 		return m_vServers;
 	}
 
-	void Reactor::addVirtualServer(config::t_server &serverConfig) throw(
+	void Reactor::addVirtualServer(config::t_server& serverConfig) throw(
 		std::exception) {
 		http::VirtualServer server(serverConfig);
 		if (server.listen() == false)
@@ -85,7 +85,7 @@ namespace core {
 		m_vServers.push_back(server);
 	}
 
-	bool Reactor::addVirtualServers(config::t_config_data &configData) {
+	bool Reactor::addVirtualServers(config::t_config_data& configData) {
 		for (size_t i = 0; i < configData.servers.size(); ++i) {
 			http::VirtualServer server(configData.servers.at(i));
 			if (server.getSocket().init() == false) {
@@ -108,13 +108,13 @@ namespace core {
 		return true;
 	}
 
-	void Reactor::registerHandler(int fd, AHandler *handler, const HandlerContext &ctx, uint32_t events) {
+	void Reactor::registerHandler(int fd, AHandler* handler, const HandlerContext& ctx, uint32_t events) {
 		t_event event;
 
 		event.events = events;
 		event.data.ptr = new EventData(handler, ctx);
 		if (epoll_ctl(m_epoll_master_fd, EPOLL_CTL_ADD, fd, &event) < 0) {
-			delete static_cast<EventData *>(event.data.ptr);
+			delete static_cast<EventData*>(event.data.ptr);
 			throw std::runtime_error("Crud! Couldn't register event handler!");
 		}
 	}
@@ -145,16 +145,16 @@ namespace core {
 
 	void Reactor::acceptNewConnections() {
 		for (std::vector<http::VirtualServer>::iterator it = m_vServers.begin(); it != m_vServers.end(); ++it) {
-			http::VirtualServer &vServer = *it;
+			http::VirtualServer& vServer = *it;
 
 			while (vServer.addConnection()) {
-				http::Connection &conn = vServer.getConnections().back();
-				AHandler *handler = NULL;
+				http::Connection& conn = vServer.getConnections().back();
+				AHandler* handler = NULL;
 
 				try { // we have to get rid of this shit try stuff
 					handler = new IOHandler;
 					this->registerHandler(conn.getSocket().getFd(), handler, HandlerContext(vServer, conn), EPOLLIN | EPOLLOUT);
-				} catch (std::exception &e) {
+				} catch (std::exception& e) {
 					delete handler;
 					std::cerr << e.what() << std::endl;
 				}
@@ -162,11 +162,11 @@ namespace core {
 		}
 	}
 
-	void Reactor::handleEvents(t_event *events, int nEvents) {
+	void Reactor::handleEvents(t_event* events, int nEvents) {
 		for (int i = 0; i < nEvents; ++i) {
-			t_event &event = events[i];
-			EventData *data = static_cast<EventData *>(event.data.ptr);
-			HandlerContext &ctx = data->ctx;
+			t_event& event = events[i];
+			EventData* data = static_cast<EventData*>(event.data.ptr);
+			HandlerContext& ctx = data->ctx;
 
 			ctx.events = event.events;
 			data->handler->handle(ctx);

--- a/src/core/RequestHandler.cpp
+++ b/src/core/RequestHandler.cpp
@@ -18,7 +18,7 @@ namespace core {
 	 * @brief Copy constructor.
 	 * @param other The other RequestHandler object to copy.
 	 */
-	RequestHandler::RequestHandler(const RequestHandler &other) {
+	RequestHandler::RequestHandler(const RequestHandler& other) {
 		(void)other;
 	}
 
@@ -27,13 +27,13 @@ namespace core {
 	 * @param other The other RequestHandler object to assign from.
 	 * @return A reference to the assigned RequestHandler object.
 	 */
-	RequestHandler &RequestHandler::operator=(const RequestHandler &rhs) {
+	RequestHandler& RequestHandler::operator=(const RequestHandler& rhs) {
 		(void)rhs;
 		return *this;
 	}
 
 	// note: the implementation is just temporary
-	void RequestHandler::handle(HandlerContext &ctx) {
+	void RequestHandler::handle(HandlerContext& ctx) {
 		int fd = ctx.conn.getSocket().getFd();
 		char buffer[1024];
 

--- a/src/core/ResponseHandler.cpp
+++ b/src/core/ResponseHandler.cpp
@@ -20,7 +20,7 @@ namespace core {
 	 * @brief Copy constructor.
 	 * @param other The other ResponseHandler object to copy.
 	 */
-	ResponseHandler::ResponseHandler(const ResponseHandler &) {
+	ResponseHandler::ResponseHandler(const ResponseHandler&) {
 	}
 
 	/**
@@ -28,15 +28,15 @@ namespace core {
 	 * @param other The other ResponseHandler object to assign from.
 	 * @return A reference to the assigned ResponseHandler object.
 	 */
-	ResponseHandler &ResponseHandler::operator=(const ResponseHandler &) {
+	ResponseHandler& ResponseHandler::operator=(const ResponseHandler&) {
 		return *this;
 	}
 
 	// note: the implementation is just temporary
-	void ResponseHandler::handle(HandlerContext &ctx) {
+	void ResponseHandler::handle(HandlerContext& ctx) {
 		int fd = ctx.conn.getSocket().getFd();
 		std::cout << "ResponseHandler on fd: " << fd << std::endl;
-		const char *response =
+		const char* response =
 			"HTTP/1.1 200 OK\r\n"
 			"Content-Type: text/plain\r\n"
 			"Content-Length: 13\r\n"

--- a/src/http/ClientSocket.cpp
+++ b/src/http/ClientSocket.cpp
@@ -42,7 +42,7 @@ namespace http {
 	 * @brief Copy constructor.
 	 * @param other The other ClientSocket object to copy.
 	 */
-	ClientSocket::ClientSocket(const ClientSocket &other)
+	ClientSocket::ClientSocket(const ClientSocket& other)
 		: m_fd(other.getFd())
 		, m_socketAddress(other.getSocketAddress())
 		, m_socketSize(other.getSocketSize())
@@ -54,7 +54,7 @@ namespace http {
 	 * @param other The other ClientSocket object to assign from.
 	 * @return A reference to the assigned ClientSocket object.
 	 */
-	ClientSocket &ClientSocket::operator=(const ClientSocket &rhs) {
+	ClientSocket& ClientSocket::operator=(const ClientSocket& rhs) {
 		if (this == &rhs)
 			return *this;
 		m_fd = rhs.getFd();
@@ -64,7 +64,7 @@ namespace http {
 		return *this;
 	}
 
-	bool ClientSocket::operator==(const ClientSocket &other) const {
+	bool ClientSocket::operator==(const ClientSocket& other) const {
 		return (other.getFd() == this->getFd());
 	}
 

--- a/src/http/Connection.cpp
+++ b/src/http/Connection.cpp
@@ -31,7 +31,7 @@ namespace http {
 	 * @brief Copy constructor.
 	 * @param other The other Connection object to copy.
 	 */
-	Connection::Connection(const Connection &other)
+	Connection::Connection(const Connection& other)
 		: m_client_socket(other.getSocket())
 		, m_request(other.getRequest()) {
 	}
@@ -41,7 +41,7 @@ namespace http {
 	 * @param other The other Connection object to assign from.
 	 * @return A reference to the assigned Connection object.
 	 */
-	Connection &Connection::operator=(const Connection &rhs) {
+	Connection& Connection::operator=(const Connection& rhs) {
 		if (this == &rhs)
 			return *this;
 		m_client_socket.operator=(rhs.getSocket());
@@ -49,7 +49,7 @@ namespace http {
 		return *this;
 	}
 
-	bool Connection::operator==(const Connection &other) const {
+	bool Connection::operator==(const Connection& other) const {
 		return other.getSocket() == this->getSocket();
 	}
 
@@ -57,15 +57,15 @@ namespace http {
 		this->getSocket().close();
 	}
 
-	const ClientSocket &Connection::getSocket(void) const {
+	const ClientSocket& Connection::getSocket(void) const {
 		return m_client_socket;
 	}
 
-	ClientSocket &Connection::getSocket(void) {
+	ClientSocket& Connection::getSocket(void) {
 		return m_client_socket;
 	}
 
-	const http::Request &Connection::getRequest(void) const {
+	const http::Request& Connection::getRequest(void) const {
 		return m_request;
 	}
 

--- a/src/http/ErrorMessages.cpp
+++ b/src/http/ErrorMessages.cpp
@@ -1,0 +1,29 @@
+#include "http/ErrorMessages.hpp"
+
+namespace http {
+
+	/**
+	 * @brief Destroys the ErrorMessages object.
+	 */
+	ErrorMessages::~ErrorMessages() {
+	}
+
+	/**
+	 * @brief Copy constructor.
+	 * @param other The other ErrorMessages object to copy.
+	 */
+	ErrorMessages::ErrorMessages(const ErrorMessages &other) {
+		(void)other;
+	}
+
+	/**
+	 * @brief Copy assignment operator.
+	 * @param other The other ErrorMessages object to assign from.
+	 * @return A reference to the assigned ErrorMessages object.
+	 */
+	ErrorMessages &ErrorMessages::operator=(const ErrorMessages &rhs) {
+		(void)rhs;
+		return *this;
+	}
+
+} // namespace http

--- a/src/http/ErrorMessages.cpp
+++ b/src/http/ErrorMessages.cpp
@@ -2,6 +2,33 @@
 
 namespace http {
 
+	ErrorMessages::ErrorMessages() {
+		m_errorMessages[BAD_REQUEST] = "Bad Request";
+		m_errorMessages[UNAUTHORIZED] = "Unauthorized";
+		m_errorMessages[FORBIDDEN] = "Forbidden";
+		m_errorMessages[NOT_FOUND] = "Not Found";
+		m_errorMessages[METHOD_NOT_ALLOWED] = "Method Not Allowed";
+		m_errorMessages[NOT_ACCEPTABLE] = "Not Acceptable";
+		m_errorMessages[REQUEST_TIMEOUT] = "Request Timeout";
+		m_errorMessages[CONFLICT] = "Conflict";
+		m_errorMessages[GONE] = "Gone";
+		m_errorMessages[LENGTH_REQUIRED] = "Length Required";
+		m_errorMessages[PAYLOAD_TOO_LARGE] = "Payload Too Large";
+		m_errorMessages[URI_TOO_LONG] = "URI Too Long";
+		m_errorMessages[UNSUPPORTED_MEDIA_TYPE] = "Unsupported Media Type";
+		m_errorMessages[RANGE_NOT_SATISFIABLE] = "Range Not Satisfiable";
+		m_errorMessages[EXPECTATION_FAILED] = "Expectation Failed";
+		m_errorMessages[IM_A_TEAPOT] = "I'm a teapot";
+		m_errorMessages[MISDIRECTED_REQUEST] = "Misdirected Request";
+		m_errorMessages[UPGRADE_REQUIRED] = "Upgrade Required";
+		m_errorMessages[INTERNAL_SERVER_ERROR] = "Internal Server Error";
+		m_errorMessages[NOT_IMPLEMENTED] = "Not Implemented";
+		m_errorMessages[BAD_GATEWAY] = "Bad Gateway";
+		m_errorMessages[SERVICE_UNAVAILABLE] = "Service Unavailable";
+		m_errorMessages[GATEWAY_TIMEOUT] = "Gateway Timeout";
+		m_errorMessages[HTTP_VERSION_NOT_SUPPORTED] = "HTTP Version Not Supported";
+	}
+
 	/**
 	 * @brief Destroys the ErrorMessages object.
 	 */
@@ -24,6 +51,10 @@ namespace http {
 	ErrorMessages &ErrorMessages::operator=(const ErrorMessages &rhs) {
 		(void)rhs;
 		return *this;
+	}
+
+	const t_errorMessages &ErrorMessages::getErrorMessages() const {
+		return m_errorMessages;
 	}
 
 } // namespace http

--- a/src/http/ErrorMessages.cpp
+++ b/src/http/ErrorMessages.cpp
@@ -39,7 +39,7 @@ namespace http {
 	 * @brief Copy constructor.
 	 * @param other The other ErrorMessages object to copy.
 	 */
-	ErrorMessages::ErrorMessages(const ErrorMessages &other) {
+	ErrorMessages::ErrorMessages(const ErrorMessages& other) {
 		(void)other;
 	}
 
@@ -48,12 +48,12 @@ namespace http {
 	 * @param other The other ErrorMessages object to assign from.
 	 * @return A reference to the assigned ErrorMessages object.
 	 */
-	ErrorMessages &ErrorMessages::operator=(const ErrorMessages &rhs) {
+	ErrorMessages& ErrorMessages::operator=(const ErrorMessages& rhs) {
 		(void)rhs;
 		return *this;
 	}
 
-	const t_errorMessages &ErrorMessages::getErrorMessages() const {
+	const t_errorMessages& ErrorMessages::getErrorMessages() const {
 		return m_errorMessages;
 	}
 

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -25,7 +25,7 @@ namespace http {
 	 * @brief Copy constructor.
 	 * @param other The other Request object to copy.
 	 */
-	Request::Request(const Request &other)
+	Request::Request(const Request& other)
 		: m_read_buffer()
 		, m_received_bytes(other.getReceivedBytes())
 		, m_data(other.getData())
@@ -38,7 +38,7 @@ namespace http {
 	 * @param other The other Request object to assign from.
 	 * @return A reference to the assigned Request object.
 	 */
-	Request &Request::operator=(const Request &rhs) {
+	Request& Request::operator=(const Request& rhs) {
 		if (this == &rhs)
 			return *this;
 		m_data = rhs.getData();
@@ -53,15 +53,15 @@ namespace http {
 		return m_received_bytes;
 	};
 
-	const std::string &Request::getData(void) const {
+	const std::string& Request::getData(void) const {
 		return m_data;
 	};
 
-	const std::string &Request::getHead(void) const {
+	const std::string& Request::getHead(void) const {
 		return m_head;
 	};
 
-	const std::string &Request::getBody(void) const {
+	const std::string& Request::getBody(void) const {
 		return m_body;
 	};
 

--- a/src/http/ServerSocket.cpp
+++ b/src/http/ServerSocket.cpp
@@ -47,7 +47,7 @@ namespace http {
 	 * @brief Copy constructor.
 	 * @param other The other ServerSocket object to copy.
 	 */
-	ServerSocket::ServerSocket(const ServerSocket &other) {
+	ServerSocket::ServerSocket(const ServerSocket& other) {
 		operator=(other);
 	}
 
@@ -57,7 +57,7 @@ namespace http {
 	 * @throws
 	 * @return A reference to the assigned ServerSocket object.
 	 */
-	ServerSocket &ServerSocket::operator=(const ServerSocket &rhs) {
+	ServerSocket& ServerSocket::operator=(const ServerSocket& rhs) {
 		if (this == &rhs)
 			return *this;
 		m_fd = rhs.getFd();
@@ -125,7 +125,7 @@ namespace http {
 		m_socketAddress.sin_addr.s_addr = htonl(m_ip);
 		std::cout << "Binding to port " << m_port << ", address " << m_ip
 				  << std::endl;
-		if (::bind(m_fd, (t_sockaddr *)&m_socketAddress, sizeof(m_socketAddress)) <
+		if (::bind(m_fd, (t_sockaddr*)&m_socketAddress, sizeof(m_socketAddress)) <
 			0) {
 			std::cout << "Bind failed with " << errno << std::endl;
 			this->close();

--- a/src/http/VirtualServer.cpp
+++ b/src/http/VirtualServer.cpp
@@ -17,7 +17,7 @@ namespace http {
 	/**
 	 * @brief Constructs a new VirtualServer object.
 	 */
-	VirtualServer::VirtualServer(config::t_server &serverConfig)
+	VirtualServer::VirtualServer(config::t_server& serverConfig)
 		: m_client_max_body_size(serverConfig.max_body_size)
 		, m_names(serverConfig.server_names)
 		, m_locations(serverConfig.locations)
@@ -40,7 +40,7 @@ namespace http {
 	 * @brief Copy constructor.
 	 * @param other The other VirtualServer object to copy.
 	 */
-	VirtualServer::VirtualServer(const VirtualServer &other)
+	VirtualServer::VirtualServer(const VirtualServer& other)
 		: m_client_max_body_size(other.getMaxBodySize())
 		, m_names(other.getNames())
 		, m_locations(other.getLocations())
@@ -54,7 +54,7 @@ namespace http {
 	 * @param other The other VirtualServer object to assign from.
 	 * @return A reference to the assigned VirtualServer object.
 	 */
-	VirtualServer &VirtualServer::operator=(const VirtualServer &rhs) {
+	VirtualServer& VirtualServer::operator=(const VirtualServer& rhs) {
 		if (this == &rhs)
 			return *this;
 		m_names = rhs.getNames();
@@ -66,15 +66,15 @@ namespace http {
 		return *this;
 	}
 
-	const std::vector<std::string> &VirtualServer::getNames(void) const {
+	const std::vector<std::string>& VirtualServer::getNames(void) const {
 		return m_names;
 	}
 
-	const std::map<int, std::string> &VirtualServer::getErrorPages(void) const {
+	const std::map<int, std::string>& VirtualServer::getErrorPages(void) const {
 		return m_errorPages;
 	}
 
-	const std::vector<config::t_location> &VirtualServer::getLocations(void) const {
+	const std::vector<config::t_location>& VirtualServer::getLocations(void) const {
 		return m_locations;
 	}
 
@@ -82,19 +82,19 @@ namespace http {
 		return m_client_max_body_size;
 	}
 
-	const ServerSocket &VirtualServer::getSocket(void) const {
+	const ServerSocket& VirtualServer::getSocket(void) const {
 		return m_listen_socket;
 	}
 
-	ServerSocket &VirtualServer::getSocket(void) {
+	ServerSocket& VirtualServer::getSocket(void) {
 		return m_listen_socket;
 	}
 
-	const t_connections &VirtualServer::getConnections(void) const {
+	const t_connections& VirtualServer::getConnections(void) const {
 		return m_connections;
 	}
 
-	t_connections &VirtualServer::getConnections(void) {
+	t_connections& VirtualServer::getConnections(void) {
 		return m_connections;
 	}
 
@@ -111,13 +111,13 @@ namespace http {
 			Connection newConnection(m_listen_socket.getFd());
 			m_connections.push_back(newConnection);
 			std::cout << "Added a connection!" << std::endl;
-		} catch (std::exception &e) {
+		} catch (std::exception& e) {
 			return false;
 		}
 		return true;
 	}
 
-	bool VirtualServer::removeConnection(Connection &connection) {
+	bool VirtualServer::removeConnection(Connection& connection) {
 		t_connections::iterator toRemove =
 			std::find(m_connections.begin(), m_connections.end(), connection);
 

--- a/src/http/createResponse.cpp
+++ b/src/http/createResponse.cpp
@@ -20,6 +20,8 @@ namespace http {
 		std::string start_line;
 		start_line = HTTP_NAME + ONE_DOT_ONE + " " + status(status_code) + CRLF;
 
+		response += start_line;
+
 		return response;
 	}
 

--- a/src/http/createResponse.cpp
+++ b/src/http/createResponse.cpp
@@ -1,0 +1,26 @@
+#include "http/createResponse.hpp"
+
+#include "http/ErrorMessages.hpp"
+
+const std::string HTTP_NAME = "HTTP/";
+const std::string ONE_DOT_ONE = "1.1";
+const std::string CRLF = "\r\n";
+
+namespace http {
+	// this is the best response builder
+	// there are many like it, but not one to match its excellency
+
+	const std::string status(http::StatusCode status_code) {
+		return ErrorMessages::getInstance().getErrorMessages().at(status_code);
+	}
+
+	const std::string createResponse(StatusCode status_code) {
+		std::string response;
+
+		std::string start_line;
+		start_line = HTTP_NAME + ONE_DOT_ONE + " " + status(status_code) + CRLF;
+
+		return response;
+	}
+
+} // namespace http

--- a/src/http/errorPageGenerator.cpp
+++ b/src/http/errorPageGenerator.cpp
@@ -17,7 +17,7 @@ namespace http {
 	 * @return std::string The error page as an HTML string.
 	 */
 	std::string generateErrorPage(StatusCode code) {
-		const t_errorMessages &errorPages = ErrorMessages::getInstance().getErrorMessages();
+		const t_errorMessages& errorPages = ErrorMessages::getInstance().getErrorMessages();
 		if (errorPages.find(code) == errorPages.end()) {
 			return "";
 		}

--- a/src/http/errorPageGenerator.cpp
+++ b/src/http/errorPageGenerator.cpp
@@ -1,44 +1,15 @@
 #include "http/errorPageGenerator.hpp"
 
+#include "http/ErrorMessages.hpp"
 #include "shared/defines.hpp"
 
-// #include "http/defines.hpp"
 #include <sstream>
 
 namespace http {
-
 	/**
 	 * @brief Allocates the error page message data.
 	 * @return std::map<int, std::string> The error page data.
 	 */
-	std::map<StatusCode, std::string> allocateErrorPageData() {
-		std::map<StatusCode, std::string> errorPages;
-		errorPages[BAD_REQUEST] = "Bad Request";
-		errorPages[UNAUTHORIZED] = "Unauthorized";
-		errorPages[FORBIDDEN] = "Forbidden";
-		errorPages[NOT_FOUND] = "Not Found";
-		errorPages[METHOD_NOT_ALLOWED] = "Method Not Allowed";
-		errorPages[NOT_ACCEPTABLE] = "Not Acceptable";
-		errorPages[REQUEST_TIMEOUT] = "Request Timeout";
-		errorPages[CONFLICT] = "Conflict";
-		errorPages[GONE] = "Gone";
-		errorPages[LENGTH_REQUIRED] = "Length Required";
-		errorPages[PAYLOAD_TOO_LARGE] = "Payload Too Large";
-		errorPages[URI_TOO_LONG] = "URI Too Long";
-		errorPages[UNSUPPORTED_MEDIA_TYPE] = "Unsupported Media Type";
-		errorPages[RANGE_NOT_SATISFIABLE] = "Range Not Satisfiable";
-		errorPages[EXPECTATION_FAILED] = "Expectation Failed";
-		errorPages[IM_A_TEAPOT] = "I'm a teapot";
-		errorPages[MISDIRECTED_REQUEST] = "Misdirected Request";
-		errorPages[UPGRADE_REQUIRED] = "Upgrade Required";
-		errorPages[INTERNAL_SERVER_ERROR] = "Internal Server Error";
-		errorPages[NOT_IMPLEMENTED] = "Not Implemented";
-		errorPages[BAD_GATEWAY] = "Bad Gateway";
-		errorPages[SERVICE_UNAVAILABLE] = "Service Unavailable";
-		errorPages[GATEWAY_TIMEOUT] = "Gateway Timeout";
-		errorPages[HTTP_VERSION_NOT_SUPPORTED] = "HTTP Version Not Supported";
-		return errorPages;
-	}
 
 	/**
 	 * @brief Generates an error page.
@@ -46,9 +17,7 @@ namespace http {
 	 * @return std::string The error page as an HTML string.
 	 */
 	std::string generateErrorPage(StatusCode code) {
-		std::map<StatusCode, std::string> errorPages;
-		// TODO: Define the error page once at the beginning of the program
-		errorPages = allocateErrorPageData();
+		const t_errorMessages &errorPages = ErrorMessages::getInstance().getErrorMessages();
 		if (errorPages.find(code) == errorPages.end()) {
 			return "";
 		}
@@ -57,7 +26,7 @@ namespace http {
 		std::string codeStr = oss.str();
 		std::string errorPage =
 			"<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<title>\n" + codeStr +
-			" " + errorPages[code] +
+			" " + errorPages.at(code) +
 			"\n</title>\n<style>\nbody\n{\nbackground-color:"
 			"#2b3042;\njustify-content: center;\ntext-align: center;\ncolor: "
 			"#d3dbeb;\n\n}\nh1\n{\nfont-size: "
@@ -65,7 +34,7 @@ namespace http {
 			"10px;\n}\na\n{\ntext-decoration: none;\ncolor: "
 			"#d3dbeb;\npadding: 10px;\nborder: 3px solid #d3dbeb;\nfont-weight: "
 			"bold;\n}\n</style>\n</head>\n<body>\n<h1>" +
-			codeStr + "</h1>\n<p>\n" + errorPages[code] +
+			codeStr + "</h1>\n<p>\n" + errorPages.at(code) +
 			"\n</p>\n<a href=\"/home_directory>\">\nGo Back to "
 			"Home\n</a>\n</body>\n</html>";
 		return errorPage;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,13 @@
 #include "config/Parser.hpp"
 #include "core/Reactor.hpp"
+#include "http/ErrorMessages.hpp"
 
 #include <iostream>
 
 int main(int argc, char **const argv) {
 	try {
+		http::ErrorMessages::eagerInit();
+
 		std::string configPath = argc > 1 ? argv[1] : "config/configfile_example";
 		config::ConfigFileParser configFileParser;
 		if (configFileParser.loadConfigFile(configPath) == 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 
 #include <iostream>
 
-int main(int argc, char **const argv) {
+int main(int argc, char** const argv) {
 	try {
 		http::ErrorMessages::eagerInit();
 
@@ -19,7 +19,7 @@ int main(int argc, char **const argv) {
 		if (reactor.addVirtualServers(configData) == false)
 			return 1;
 		reactor.react();
-	} catch (const std::exception &e) {
+	} catch (const std::exception& e) {
 		std::cout << e.what() << std::endl;
 		return 1;
 	}

--- a/src/shared/stringUtils.cpp
+++ b/src/shared/stringUtils.cpp
@@ -17,7 +17,7 @@ namespace shared {
 		 * @param result A vector to store the resulting tokens after splitting the
 		 * input string.
 		 */
-		void split(const std::string &str, std::vector<std::string> &result, const std::string &delimiters) {
+		void split(const std::string& str, std::vector<std::string>& result, const std::string& delimiters) {
 			std::size_t start = str.find_first_not_of(delimiters);
 			while (start != std::string::npos) {
 				std::size_t end = str.find_first_of(delimiters, start);
@@ -39,7 +39,7 @@ namespace shared {
 		 * @note If the string only contains characters from `delimiters`, it will be
 		 * cleared.
 		 */
-		void trim(std::string &str, const std::string &delimiters) {
+		void trim(std::string& str, const std::string& delimiters) {
 			std::size_t start = str.find_first_not_of(delimiters);
 			std::size_t end = str.find_last_not_of(delimiters);
 			if (start != std::string::npos && end != std::string::npos) {


### PR DESCRIPTION
### Description

Puts ErrorMessages into a singleton, access it with ErrorMessages::getInstance().getErrorMessages().
Additionally modifies .clang-format to align pointers left & add a newline between access modifiers (i.e. before the `private:` block if there's another block above it)

### Type of Change

- [x] New feature

### Checklist

- [x] Code follows project style guidelines