### PR TITLE
Feat/add chunk extentions

### DIFF
--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -22,6 +22,12 @@ namespace http {
 			std::string body;
 			std::map<std::string, std::vector<std::string> > trailingHeaders;
 	} t_requestData;
+	
+	typedef struct s_chunkedExtension {
+		unsigned long start;
+		unsigned long end;
+		std::map<std::string, std::string> extensions;
+	} t_chunkedExtension;
 
 	enum QuoteFlag {
 		NO_QUOTE = 0,
@@ -72,6 +78,7 @@ namespace http {
 			const RequestStatus& getStatus(void) const;
 			const ExpectedBody& getExpectedBody(void) const;
 			const ChunkedStatus& getChunkedStatus(void) const;
+			const std::vector<t_chunkedExtension>& getChunkedExtensions(void) const;
 
 			void PrintRequestData();
 			bool parse(char buffer[BUFFER_SIZE]);
@@ -86,6 +93,7 @@ namespace http {
 			RequestStatus m_status;
 			ExpectedBody m_expectedBody;
 			ChunkedStatus m_chunkedStatus;
+			std::vector<t_chunkedExtension> m_chunkedExtensions;
 
 			bool parseHead(std::string& input);
 			bool parseHeaders(std::string& input, HeaderType type);
@@ -94,6 +102,8 @@ namespace http {
 			bool parseHeader(std::string& line, HeaderType type);
 			bool interpretHeaders(HeaderType type);
 			bool parseBodyChunked(std::string& input);
+			bool parseChunkExtentions(std::string& line);
+			bool parseBodyChunkedSize(std::string& input);
 			bool checkHead(const std::vector<std::string>& args);
 			GetLineStatus getNextLineHTTP(std::string& input, std::string& line);
 

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -22,11 +22,11 @@ namespace http {
 			std::string body;
 			std::map<std::string, std::vector<std::string> > trailingHeaders;
 	} t_requestData;
-	
+
 	typedef struct s_chunkedExtension {
-		unsigned long start;
-		unsigned long end;
-		std::map<std::string, std::string> extensions;
+			unsigned long start;
+			unsigned long end;
+			std::map<std::string, std::string> extensions;
 	} t_chunkedExtension;
 
 	enum QuoteFlag {

--- a/src/http/Parse_body.cpp
+++ b/src/http/Parse_body.cpp
@@ -25,36 +25,15 @@ namespace http {
 
 	bool Request::parseBodyChunked(std::string& input) {
 		while (1) {
-			if (m_chunkedStatus == CHUNK_SIZE) {
-				std::string line;
-				GetLineStatus status = getNextLineHTTP(input, line);
-				if (status == GET_LINE_ERROR) {
+			if (m_chunkedStatus == CHUNK_SIZE) { //reading chunk size and chunk extentions
+				if (!parseBodyChunkedSize(input)) {
 					return false;
-				}
-				if (status == GET_LINE_OK) {
-					if (line == "") {
-						LOG("Error: Empty line in chunked encoding", 1);
-						return false;
-					} else {
-						int ret = 0;
-						m_contentLength = shared::string::StoiHex(line, ret);
-						if (ret == -1) {
-							LOG("Error: Invalid hexadecimal number in chunked encoding", 1);
-							return false;
-						}
-						if (m_contentLength == 0) {
-							m_chunkedStatus = CHUNK_END;
-						} else {
-							m_chunkedStatus = CHUNK_DATA;
-						}
-						// if (line != "") { //TODO: chunk extension
-					}
 				}
 				if (m_chunkedStatus == CHUNK_SIZE) {
 					return true;
 				}
 			}
-			if (m_chunkedStatus == CHUNK_DATA) {
+			if (m_chunkedStatus == CHUNK_DATA) { //reading chunk data
 				std::string chunk = input.substr(0, m_contentLength);
 				m_contentLength -= chunk.size();
 				m_requestData.body += chunk;
@@ -65,7 +44,7 @@ namespace http {
 					return true;
 				}
 			}
-			if (m_chunkedStatus == CHUNK_DATA_END) {
+			if (m_chunkedStatus == CHUNK_DATA_END) { //skipping the \r\n after chunk
 				if (input.length() < 2) {
 					return true;
 				}
@@ -81,6 +60,103 @@ namespace http {
 				return parseHeaders(input, TRAILING);
 			}
 		}
+	}
+
+	bool Request::parseBodyChunkedSize(std::string& input) {
+		std::string line;
+		GetLineStatus status = getNextLineHTTP(input, line);
+		if (status == GET_LINE_ERROR) {
+			return false;
+		}
+		if (status == GET_LINE_OK) {
+			if (line == "") {
+				LOG("Error: Empty line in chunked encoding", 1);
+				return false;
+			} else {
+				int ret = 0;
+				m_contentLength = shared::string::StoiHex(line, ret);
+				if (ret == -1) {
+					LOG("Error: Invalid hexadecimal number in chunked encoding", 1);
+					return false;
+				}
+				if (m_contentLength == 0) {
+					m_chunkedStatus = CHUNK_END;
+				} else {
+					m_chunkedStatus = CHUNK_DATA;
+				}
+				if (line != "") { //TODO: chunk extension
+					if (!parseChunkExtentions(line)) {
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	}
+
+	void removeWhitespaces(std::string& line) {
+		while (line[0] == ' ' || line[0] == '\t') {
+			line = line.substr(1);
+		}	
+	}
+
+	bool Request::parseChunkExtentions(std::string& line) {
+		std::string key;
+		std::string value;
+		bool hasValue = false;
+		t_chunkedExtension chunkedExtension;
+		chunkedExtension.start = m_requestData.body.size();
+		chunkedExtension.end = chunkedExtension.start + m_contentLength;
+		while (line != "") {
+			key = "";
+			value = "";
+			hasValue = false;
+			removeWhitespaces(line);
+			if (line[0] == ';') //find next chunked extention
+				line = line.substr(1);
+			else {
+				LOG("Error: Invalid chunked extention, \";\" expected after chunk size or other chunked extention", 1);
+				return false;
+			}
+			removeWhitespaces(line);
+			while (line != "" && line[0] != ' ' && line[0] != '\t' && line[0] != '=' && line[0] != ';') { //find Key 
+				key += line[0];
+				if (key.length() > 100) {
+					LOG("Error: Invalid chunked extention, key too long", 1);
+					return false;
+				}
+				line = line.substr(1);
+			}
+			removeWhitespaces(line);
+			if (line[0] == '=') { 
+				line = line.substr(1);
+				hasValue = true;
+				removeWhitespaces(line);
+				while (line != "" && line[0] != ' ' && line[0] != '\t' && line[0] != ';') { //find value
+					value += line[0];
+					if (value.length() > 1000) {
+						LOG("Error: Invalid chunked extention, value too long", 1);
+						return false;
+					}
+					line = line.substr(1);
+				}
+			}
+			if (key == "") {
+				LOG("Error: Invalid chunked extention, (non-empty) key expected", 1);
+				return false;
+			}
+			if (hasValue && value == "") {
+				LOG("Error: Invalid chunked extention, (non-empty) value expected", 1);
+				return false;
+			}
+			chunkedExtension.extensions[key] = value; //save that chunked extention data
+			if (chunkedExtension.extensions.size() > 1000) {
+				LOG("Error: Invalid chunked extention, too many extensions", 1);
+				return false;
+			}	
+		}
+		m_chunkedExtensions.push_back(chunkedExtension);
+		return true;
 	}
 
 } /* namespace http */

--- a/src/http/Parse_body.cpp
+++ b/src/http/Parse_body.cpp
@@ -25,7 +25,7 @@ namespace http {
 
 	bool Request::parseBodyChunked(std::string& input) {
 		while (1) {
-			if (m_chunkedStatus == CHUNK_SIZE) { //reading chunk size and chunk extentions
+			if (m_chunkedStatus == CHUNK_SIZE) { // reading chunk size and chunk extentions
 				if (!parseBodyChunkedSize(input)) {
 					return false;
 				}
@@ -33,7 +33,7 @@ namespace http {
 					return true;
 				}
 			}
-			if (m_chunkedStatus == CHUNK_DATA) { //reading chunk data
+			if (m_chunkedStatus == CHUNK_DATA) { // reading chunk data
 				std::string chunk = input.substr(0, m_contentLength);
 				m_contentLength -= chunk.size();
 				m_requestData.body += chunk;
@@ -44,7 +44,7 @@ namespace http {
 					return true;
 				}
 			}
-			if (m_chunkedStatus == CHUNK_DATA_END) { //skipping the \r\n after chunk
+			if (m_chunkedStatus == CHUNK_DATA_END) { // skipping the \r\n after chunk
 				if (input.length() < 2) {
 					return true;
 				}
@@ -84,7 +84,7 @@ namespace http {
 				} else {
 					m_chunkedStatus = CHUNK_DATA;
 				}
-				if (line != "") { //TODO: chunk extension
+				if (line != "") { // TODO: chunk extension
 					if (!parseChunkExtentions(line)) {
 						return false;
 					}
@@ -97,29 +97,28 @@ namespace http {
 	void removeWhitespaces(std::string& line) {
 		while (line[0] == ' ' || line[0] == '\t') {
 			line = line.substr(1);
-		}	
+		}
 	}
 
 	bool Request::parseChunkExtentions(std::string& line) {
 		std::string key;
 		std::string value;
-		bool hasValue = false;
 		t_chunkedExtension chunkedExtension;
 		chunkedExtension.start = m_requestData.body.size();
 		chunkedExtension.end = chunkedExtension.start + m_contentLength;
 		while (line != "") {
 			key = "";
 			value = "";
-			hasValue = false;
+			bool hasValue = false;
 			removeWhitespaces(line);
-			if (line[0] == ';') //find next chunked extention
+			if (line[0] == ';') // find next chunked extention
 				line = line.substr(1);
 			else {
 				LOG("Error: Invalid chunked extention, \";\" expected after chunk size or other chunked extention", 1);
 				return false;
 			}
 			removeWhitespaces(line);
-			while (line != "" && line[0] != ' ' && line[0] != '\t' && line[0] != '=' && line[0] != ';') { //find Key 
+			while (line != "" && line[0] != ' ' && line[0] != '\t' && line[0] != '=' && line[0] != ';') { // find Key
 				key += line[0];
 				if (key.length() > 100) {
 					LOG("Error: Invalid chunked extention, key too long", 1);
@@ -128,11 +127,11 @@ namespace http {
 				line = line.substr(1);
 			}
 			removeWhitespaces(line);
-			if (line[0] == '=') { 
+			if (line[0] == '=') {
 				line = line.substr(1);
 				hasValue = true;
 				removeWhitespaces(line);
-				while (line != "" && line[0] != ' ' && line[0] != '\t' && line[0] != ';') { //find value
+				while (line != "" && line[0] != ' ' && line[0] != '\t' && line[0] != ';') { // find value
 					value += line[0];
 					if (value.length() > 1000) {
 						LOG("Error: Invalid chunked extention, value too long", 1);
@@ -149,11 +148,11 @@ namespace http {
 				LOG("Error: Invalid chunked extention, (non-empty) value expected", 1);
 				return false;
 			}
-			chunkedExtension.extensions[key] = value; //save that chunked extention data
+			chunkedExtension.extensions[key] = value; // save that chunked extention data
 			if (chunkedExtension.extensions.size() > 1000) {
 				LOG("Error: Invalid chunked extention, too many extensions", 1);
 				return false;
-			}	
+			}
 		}
 		m_chunkedExtensions.push_back(chunkedExtension);
 		return true;

--- a/src/http/Parse_headers.cpp
+++ b/src/http/Parse_headers.cpp
@@ -33,6 +33,7 @@ namespace http {
 				key = line.substr(0, i);
 				promptStart = i + 1;
 			}
+			// find values
 			if ((line[i] == ',' && qf == NO_QUOTE) || i == line.size() - 1) {
 				if (i == line.size() - 1) {
 					if (line[i] != ',') {
@@ -56,7 +57,15 @@ namespace http {
 					promptStart++;
 				}
 				std::string val = line.substr(promptStart, i - promptStart);
+				if (val.length() > 1000) {
+					LOG("Request: Error: Too long value in header", 1);
+					return false;
+				}
 				values.push_back(val);
+				if (values.size() > 1000) {
+					LOG("Request: Error: Too many values in header", 1);
+					return false;
+				}
 				promptStart = i + 1;
 			}
 		}

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -34,7 +34,7 @@ namespace http {
 		, m_requestData(other.getRequestData())
 		, m_status(other.m_status)
 		, m_expectedBody(other.getExpectedBody())
-		, m_chunkedStatus(other.getChunkedStatus()) 
+		, m_chunkedStatus(other.getChunkedStatus())
 		, m_chunkedExtensions(other.getChunkedExtensions()) {}
 
 	/**
@@ -115,7 +115,7 @@ namespace http {
 		if (input != "") {
 			m_restData = input;
 		}
-		//std::cout << "Request.parse successful" << std::endl;
+		// std::cout << "Request.parse successful" << std::endl;
 		return true;
 	}
 
@@ -173,7 +173,7 @@ namespace http {
 			if (i > 10000000) {
 				LOG("Error: Line too long", 1);
 				return GET_LINE_ERROR;
-			} 
+			}
 			if (input[i] == '\r') {
 				if (i != input.length() - 1 && input[i + 1] != '\n') {
 					LOG("Error: Invalid line ending", 1);

--- a/src/shared/stringUtils.cpp
+++ b/src/shared/stringUtils.cpp
@@ -91,11 +91,11 @@ namespace shared {
 						ret = -1;
 						return 0;
 					}
-					str = str.substr(0, i);
 					break;
 				}
 				i++;
 			}
+			str = str.substr(i);
 			return result;
 		}
 


### PR DESCRIPTION
### Description

Added the parsing of Chunk extentions, which could be found directly after the chunk size in case of a chunked encoding.

### Type of Change

- [ ] Bug fix
- [X ] New feature
- [ ] Documentation update

### How to Test

insert this into the main and the play around with the values after "chunk size" in the "input" string.

		http::Request request;
		std::string input2 = "awdd\r\nContent-Length:40\r\nHost: localhost:8080,   a\r\nUser-Agent: curl/7.68.0\r\nAccept: wdadd\r\n\r\n 1234123213567890";
		std::string input = "POST / HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n1;wdad\r\nH\r\n1E;fe = =;ce  \r\nHello World! How are you today\r\n0\r\nHost: www.example.com\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
		int bytes = 1;
		for (size_t i = 0; i < input.size(); i += bytes) {
			std::string chunk = input.substr(i, bytes).c_str();
			char * chunkChar;
			chunkChar = (char *)chunk.c_str();
			if (!request.parse(chunkChar)) {
			std::cout << "Failed to parse request" << std::endl;
			return 1;
			}
		}
		std::cout << "Request parsed successfully" << std::endl;
		//request.PrintRequestData();
		return 0;

### Checklist

- [ X ] Code follows project style guidelines
- [ ] Documentation has been updated