### PR TITLE
feat: ChunkedExtentions

### DIFF
--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -14,6 +14,13 @@
 
 namespace http {
 
+	typedef struct s_chunkedExtension {
+			unsigned long start;
+			unsigned long end;
+			std::map<std::string, std::string> extensions;
+	} t_chunkedExtension;
+	
+	typedef std::vector<t_chunkedExtension> t_chunkedExtensions;
 	typedef struct s_requestData {
 			std::string method;
 			std::string uri;
@@ -21,7 +28,9 @@ namespace http {
 			std::map<std::string, std::vector<std::string> > headers;
 			std::string body;
 			std::map<std::string, std::vector<std::string> > trailingHeaders;
+			t_chunkedExtensions chunkedExtensions;
 	} t_requestData;
+
 
 	enum QuoteFlag {
 		NO_QUOTE = 0,
@@ -86,6 +95,7 @@ namespace http {
 			RequestStatus m_status;
 			ExpectedBody m_expectedBody;
 			ChunkedStatus m_chunkedStatus;
+			
 
 			bool parseHead(std::string& input);
 			bool parseHeaders(std::string& input, HeaderType type);
@@ -94,6 +104,8 @@ namespace http {
 			bool parseHeader(std::string& line, HeaderType type);
 			bool interpretHeaders(HeaderType type);
 			bool parseBodyChunked(std::string& input);
+			bool parseChunkExtentions(std::string& line);
+			bool parseBodyChunkedSize(std::string& input);
 			bool checkHead(const std::vector<std::string>& args);
 			GetLineStatus getNextLineHTTP(std::string& input, std::string& line);
 

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -150,11 +150,23 @@ namespace http {
 		std::cout << "------------------------------" << std::endl;
 		std::cout << "Body: " << m_requestData.body << std::endl;
 		std::cout << "------------------------------" << std::endl;
+		std::cout << "Chunked extensions: " << std::endl;
+		for (t_chunkedExtensions::const_iterator it = m_requestData.chunkedExtensions.begin(); it != m_requestData.chunkedExtensions.end(); ++it) {
+			std::cout << "Start: " << it->start << " End: " << it->end << std::endl;
+			for (std::map<std::string, std::string>::const_iterator ext = it->extensions.begin(); ext != it->extensions.end(); ++ext) {
+				std::cout << ext->first << ": " << ext->second << std::endl;
+			}
+		}
+		std::cout << "------------------------------" << std::endl;
 		std::cout << "Status: " << m_status << std::endl;
 	}
 
 	GetLineStatus Request::getNextLineHTTP(std::string& input, std::string& line) {
 		for (unsigned long i = 0; i < input.size(); i++) {
+			if (i > 10000000) {
+				std::cout << "Error: Line too long" << std::endl;
+				return GET_LINE_ERROR;
+			}
 			if (input[i] == '\r') {
 				if (i != input.length() - 1 && input[i + 1] != '\n') {
 					std::cout << "Error: Invalid line ending" << std::endl;

--- a/src/shared/stringUtils.cpp
+++ b/src/shared/stringUtils.cpp
@@ -91,11 +91,11 @@ namespace shared {
 						ret = -1;
 						return 0;
 					}
-					str = str.substr(0, i);
 					break;
 				}
 				i++;
 			}
+			str = str.substr(i);
 			return result;
 		}
 


### PR DESCRIPTION
### Description

Added the parsing of Chunk extentions, which could be found directly after the chunk size in case of a chunked encoding.

### Type of Change

- [ ] Bug fix
- [X ] New feature
- [ ] Documentation update

### How to Test

insert this into the main and the play around with the values after "chunk size" in the "input" string.

		http::Request request;
		std::string input2 = "awdd\r\nContent-Length:40\r\nHost: localhost:8080,   a\r\nUser-Agent: curl/7.68.0\r\nAccept: wdadd\r\n\r\n 1234123213567890";
		std::string input = "POST / HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n1;wdad\r\nH\r\n1E;fe = =;ce  \r\nHello World! How are you today\r\n0\r\nHost: www.example.com\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
		int bytes = 1;
		for (size_t i = 0; i < input.size(); i += bytes) {
			std::string chunk = input.substr(i, bytes).c_str();
			char * chunkChar;
			chunkChar = (char *)chunk.c_str();
			if (!request.parse(chunkChar)) {
			std::cout << "Failed to parse request" << std::endl;
			return 1;
			}
		}
		std::cout << "Request parsed successfully" << std::endl;
		//request.PrintRequestData();
		return 0;

### Checklist

- [ X ] Code follows project style guidelines
- [ ] Documentation has been updated