### PR TITLE
Feat/check request data

### DIFF
--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -89,7 +89,7 @@ namespace http {
 			void reset(void);
 
 			//for testing purposes
-			void setHeader(const std::string key, const std::vector<std::string> value);
+			void setHeader(const std::string& key, const std::vector<std::string>& value);
 		private:
 			uint32_t m_receivedBytes;
 			uint32_t m_contentLength;

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -88,6 +88,8 @@ namespace http {
 			bool parse(char buffer[BUFFER_SIZE]);
 			void reset(void);
 
+			//for testing purposes
+			void setHeader(const std::string key, const std::vector<std::string> value);
 		private:
 			uint32_t m_receivedBytes;
 			uint32_t m_contentLength;

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -21,13 +21,15 @@ namespace http {
 	} t_chunkedExtension;
 	
 	typedef std::vector<t_chunkedExtension> t_chunkedExtensions;
+
+	typedef std::pair<std::string, std::vector<std::string> > t_header;
 	typedef struct s_requestData {
 			std::string method;
 			std::string uri;
 			std::string version;
-			std::map<std::string, std::vector<std::string> > headers;
+			std::vector<t_header> headers;
+			std::vector<t_header> trailingHeaders;
 			std::string body;
-			std::map<std::string, std::vector<std::string> > trailingHeaders;
 			t_chunkedExtensions chunkedExtensions;
 	} t_requestData;
 

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -14,6 +14,13 @@
 
 namespace http {
 
+	typedef struct s_chunkedExtension {
+			unsigned long start;
+			unsigned long end;
+			std::map<std::string, std::string> extensions;
+	} t_chunkedExtension;
+	
+	typedef std::vector<t_chunkedExtension> t_chunkedExtensions;
 	typedef struct s_requestData {
 			std::string method;
 			std::string uri;
@@ -21,7 +28,9 @@ namespace http {
 			std::map<std::string, std::vector<std::string> > headers;
 			std::string body;
 			std::map<std::string, std::vector<std::string> > trailingHeaders;
+			t_chunkedExtensions chunkedExtensions;
 	} t_requestData;
+
 
 	enum QuoteFlag {
 		NO_QUOTE = 0,
@@ -86,6 +95,7 @@ namespace http {
 			RequestStatus m_status;
 			ExpectedBody m_expectedBody;
 			ChunkedStatus m_chunkedStatus;
+			
 
 			bool parseHead(std::string& input);
 			bool parseHeaders(std::string& input, HeaderType type);
@@ -94,6 +104,8 @@ namespace http {
 			bool parseHeader(std::string& line, HeaderType type);
 			bool interpretHeaders(HeaderType type);
 			bool parseBodyChunked(std::string& input);
+			bool parseChunkExtentions(std::string& line);
+			bool parseBodyChunkedSize(std::string& input);
 			bool checkHead(const std::vector<std::string>& args);
 			GetLineStatus getNextLineHTTP(std::string& input, std::string& line);
 

--- a/include/http/Response.hpp
+++ b/include/http/Response.hpp
@@ -16,6 +16,13 @@ namespace http {
 
 	typedef std::map<std::string, std::string> t_headerFields;
 
+	typedef struct s_PathData {
+		std::string scheme;
+		std::string authority;
+		std::string pure_path;
+		std::string query;
+	} t_PathData;
+
 	enum ResponseBuilderStatus {
 		PENDING_WRITE,
 		WRITING,
@@ -46,6 +53,7 @@ namespace http {
 			StatusCode getStatusCode(void) const;
 			const t_headerFields& getHeaderFields(void) const;
 			const std::string& getBody(void) const;
+			const t_PathData getPathData(void) const;
 
 			void setRawResponse(const std::string&); // probably just temporary
 			void doMagicToCalculateStatusCode(const Request&);
@@ -67,8 +75,14 @@ namespace http {
 			StatusCode m_statusCode;
 			t_headerFields m_headerFields;
 			std::string m_body;
-
+			t_PathData m_pathData;
+			
 			ResponseBuilderStatus m_builderStatus;
+
+			void checkRequestData(const Request &request);
+			void checkAndReconstructTargetUri(const Request &request);
+			bool parseAbsoluteForm(const std::string &path, const Request& request, t_PathData &pathData);
+			bool parseOriginForm(const std::string &path, const Request& request, t_PathData &pathData);
 	};
 
 } /* namespace http */

--- a/include/http/Response.hpp
+++ b/include/http/Response.hpp
@@ -69,6 +69,9 @@ namespace http {
 			bool done(void) const;
 			void reset(void);
 
+			// for testing purposes
+			int testParseURI(std::string uri, int mode);
+
 		private:
 			ResponseType m_type;
 			std::string m_rawResponse;

--- a/include/http/Response.hpp
+++ b/include/http/Response.hpp
@@ -70,7 +70,7 @@ namespace http {
 			void reset(void);
 
 			// for testing purposes
-			int testParseURI(std::string uri, int mode);
+			int testParseURI(const std::string& uri, int mode);
 
 		private:
 			ResponseType m_type;

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -81,7 +81,7 @@ namespace http {
 		return m_chunkedStatus;
 	};
 
-	void Request::setHeader(const std::string key, const std::vector<std::string> value) {
+	void Request::setHeader(const std::string& key, const std::vector<std::string>& value) {
 		m_requestData.headers.push_back(std::make_pair(key, value));
 	}
 

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -150,11 +150,23 @@ namespace http {
 		std::cout << "------------------------------" << std::endl;
 		std::cout << "Body: " << m_requestData.body << std::endl;
 		std::cout << "------------------------------" << std::endl;
+		std::cout << "Chunked extensions: " << std::endl;
+		for (t_chunkedExtensions::const_iterator it = m_requestData.chunkedExtensions.begin(); it != m_requestData.chunkedExtensions.end(); ++it) {
+			std::cout << "Start: " << it->start << " End: " << it->end << std::endl;
+			for (std::map<std::string, std::string>::const_iterator ext = it->extensions.begin(); ext != it->extensions.end(); ++ext) {
+				std::cout << ext->first << ": " << ext->second << std::endl;
+			}
+		}
+		std::cout << "------------------------------" << std::endl;
 		std::cout << "Status: " << m_status << std::endl;
 	}
 
 	GetLineStatus Request::getNextLineHTTP(std::string& input, std::string& line) {
 		for (unsigned long i = 0; i < input.size(); i++) {
+			if (i > 10000000) {
+				std::cout << "Error: Line too long" << std::endl;
+				return GET_LINE_ERROR;
+			}
 			if (input[i] == '\r') {
 				if (i != input.length() - 1 && input[i + 1] != '\n') {
 					std::cout << "Error: Invalid line ending" << std::endl;

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -131,7 +131,7 @@ namespace http {
 		std::cout << "Version: " << m_requestData.version << std::endl;
 		std::cout << "------------------------------" << std::endl;
 		std::cout << "Headers: " << std::endl;
-		for (std::map<std::string, std::vector<std::string> >::const_iterator it = m_requestData.headers.begin(); it != m_requestData.headers.end(); ++it) {
+		for (std::vector<t_header>::const_iterator it = m_requestData.headers.begin(); it != m_requestData.headers.end(); ++it) {
 			std::cout << it->first << ": ";
 			for (std::vector<std::string>::const_iterator val = it->second.begin(); val != it->second.end(); ++val) {
 				std::cout << *val << " ";
@@ -140,7 +140,7 @@ namespace http {
 		}
 		std::cout << "------------------------------" << std::endl;
 		std::cout << "Trailing headers: " << std::endl;
-		for (std::map<std::string, std::vector<std::string> >::const_iterator it = m_requestData.trailingHeaders.begin(); it != m_requestData.trailingHeaders.end(); ++it) {
+		for (std::vector<t_header>::const_iterator it = m_requestData.trailingHeaders.begin(); it != m_requestData.trailingHeaders.end(); ++it) {
 			std::cout << it->first << ": ";
 			for (std::vector<std::string>::const_iterator val = it->second.begin(); val != it->second.end(); ++val) {
 				std::cout << *val << " ";

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -81,6 +81,10 @@ namespace http {
 		return m_chunkedStatus;
 	};
 
+	void Request::setHeader(const std::string key, const std::vector<std::string> value) {
+		m_requestData.headers.push_back(std::make_pair(key, value));
+	}
+
 	/**
 	 * @brief Parses the request.
 	 * @return True if the request was parsed successfully, false otherwise.

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -240,7 +240,6 @@ namespace http {
 
 	bool  Response::parseOriginForm(const std::string &path, const Request& request, t_PathData &pathData)
 	{
-		std::string scheme;
 		std::string authority;
 		std::string pure_path;
 		std::string query;
@@ -333,7 +332,7 @@ namespace http {
 		} */
 	}
 
-	int Response::testParseURI(std::string uri, int mode)
+	int Response::testParseURI(const std::string& uri, int mode)
 	{
 		std::cout << "-----------------------------------" << std::endl;
 		t_PathData pathData;

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -126,7 +126,6 @@ namespace http {
 		return o;
 	}
 
-	// temporarily always error to test error response
 	void Response::doMagicToCalculateStatusCode(const Request& request) {
 		m_statusCode = OK;
 		m_type = IDK_NORMAL_I_GUESS;
@@ -134,12 +133,6 @@ namespace http {
 		if (m_type == ERROR) {
 			return;
 		}
-		/* Actuall path is saved in the m_true_path member;
-		 		
-		for CGI
-		- Parse the incoming request's URL path. (Router)
-		- Match the path against your configured CGI paths or extensions.
-		- If there's a match, treat it as a CGI request and forward it to the appropriate handler.*/
 	}
 
 	void Response::buildFromRequest(const Request& request) {
@@ -223,7 +216,6 @@ namespace http {
 		}
 		if (path.find('?') != std::string::npos) { // optional query part after the first question mark
 			query = path.substr(path.find('?') +1);
-			//TODO: Check query
 		}
 		pure_path = path.substr(path.find(':') +1, path.find('?') - path.find(':') -1);
 		if (pure_path[0] != '/' && pure_path[1] != '/') { // authority part starts with two slashes
@@ -235,6 +227,9 @@ namespace http {
 			return false;
 		}
 		authority = pure_path.substr(0, pure_path.find('/'));
+		if (authority.empty()) {
+			return false;
+		}
 		pure_path = pure_path.substr(pure_path.find('/'));
 		pathData.query = query;
 		pathData.pure_path = pure_path;
@@ -337,5 +332,39 @@ namespace http {
 			return;
 		} */
 	}
+
+	int Response::testParseURI(std::string uri, int mode)
+	{
+		std::cout << "-----------------------------------" << std::endl;
+		t_PathData pathData;
+		if (mode == 0) {
+			Request req;
+			std::vector<std::string> host;
+			host.push_back("localhost");
+			req.setHeader("Host", host);
+			if (parseOriginForm(uri, req, pathData)) {
+				std::cout << "Origin form parsed successfully" << std::endl;
+			} else {
+				std::cout << "Origin form failed" << std::endl;
+				std::cout << "-----------------------------------" << std::endl;
+				return 1;
+			}
+		} else {
+			if (parseAbsoluteForm(uri, Request(), pathData)) {
+				std::cout << "Absolute form parsed successfully" << std::endl;
+			} else {
+				std::cout << "Absolute form failed" << std::endl;
+				std::cout << "-----------------------------------" << std::endl;
+				return 1;
+			}
+		}
+		std::cout << "Scheme: " << pathData.scheme << std::endl;
+		std::cout << "Authority: " << pathData.authority << std::endl;
+		std::cout << "Pure path: " << pathData.pure_path << std::endl;
+		std::cout << "Query: " << pathData.query << std::endl;
+		std::cout << "-----------------------------------" << std::endl;
+		return 0;
+	}
+
 
 } /* namespace http */

--- a/src/shared/stringUtils.cpp
+++ b/src/shared/stringUtils.cpp
@@ -91,11 +91,11 @@ namespace shared {
 						ret = -1;
 						return 0;
 					}
-					str = str.substr(0, i);
 					break;
 				}
 				i++;
 			}
+			str = str.substr(i);
 			return result;
 		}
 


### PR DESCRIPTION
### Description

(ALREADY HAS CHANGES FROM THE "NewAddChunkedExtentions" BRANCH INCLUDED)
Implements checking for the Request line of the request and splits the URI into its components (scheme/authority/path/query)

### Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

### How to Test


		// for Testing the HTTP Request Parsing
		http::Request request;
		std::string input2 = "awdd\r\nContent-Length:40\r\nHost: localhost:8080,   a\r\nUser-Agent: curl/7.68.0\r\nAccept: wdadd\r\n\r\n 1234123213567890";
		std::string input = "POST / HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n1;wdad\r\nH\r\n1E;fe = =;ce  \r\nHello World! How are you today\r\n0\r\nHost: www.example.com\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n";
		int bytes = 1;
		for (size_t i = 0; i < input.size(); i += bytes) {
			//request.setReadBuffer(input.substr(i, bytes).c_str());
			std::string chunk = input.substr(i, bytes).c_str();
			char * chunkChar;
			chunkChar = (char *)chunk.c_str();
			if (!request.parse(chunkChar)) {
			std::cout << "Failed to parse request" << std::endl;
			return 1;
			}
		}
		std::cout << "Request parsed successfully" << std::endl;
		request.PrintRequestData();
		return 0;
		
		//For Testing the Absolute Path seperator
		{
			std::vector<std::string> tests;
			tests.push_back("https://y/user:password@[2001:db8::ff00:42:8329]:443/search?q=test#results");
			http::Response response;
			for (std::vector<std::string>::iterator it = tests.begin(); it != tests.end(); ++it) {
				response.testParseURI(*it, 1);
			}
		}
		//For Testing the Origin Path seperator
		{
			std::vector<std::string> tests;
			tests.push_back("/wdad/");
			http::Response response;
			for (std::vector<std::string>::iterator it = tests.begin(); it != tests.end(); ++it) {
				response.testParseURI(*it, 0);
			}
		}


### Checklist

- [x] Code follows project style guidelines
- [ ] Documentation has been updated