### PR TITLE
refactor(RequestHandlers): don't block on read/write

### DIFF
--- a/include/core/IOHandler.hpp
+++ b/include/core/IOHandler.hpp
@@ -27,14 +27,17 @@ namespace core {
 			void handleRead(int32_t fd);
 			void handleWrite(int32_t fd);
 
+			std::size_t getChunkSize() const { return CHUNK_SIZE; }
+
 		private:
+			static const std::size_t CHUNK_SIZE = 16384; // 16 KB
 			http::VirtualServer& m_vServer;
 
 			http::RequestParser m_reqParser;
 			http::RequestProcessor m_reqProcessor;
 
 			std::queue<http::Request*> m_requests;
-			std::queue<http::Response*> m_responses; // todo que
+			std::queue<http::Response*> m_responses;
 	};
 
 } /* namespace core */

--- a/include/http/ARequestHandler.hpp
+++ b/include/http/ARequestHandler.hpp
@@ -46,8 +46,10 @@ namespace http {
 				return m_state == DONE;
 			}
 
+			std::size_t getChunkSize() const { return CHUNK_SIZE; }
+
 		protected:
-			static const std::size_t CHUNK_SIZE = 8192;
+			static const std::size_t CHUNK_SIZE = 16384; // 16 KB
 
 			enum HandlerState {
 				PENDING,

--- a/include/http/DeleteHandler.hpp
+++ b/include/http/DeleteHandler.hpp
@@ -14,6 +14,9 @@ namespace http {
 			~DeleteHandler();
 
 			void handle(const Request& request, Response& response);
+
+		private:
+			void deleteFile(Response& response, const std::string& filePath);
 	};
 
 } /* namespace http */

--- a/include/http/DeleteHandler.hpp
+++ b/include/http/DeleteHandler.hpp
@@ -16,7 +16,7 @@ namespace http {
 			void handle(const Request& request, Response& response);
 
 		private:
-			void deleteFile(Response& response, const std::string& filePath);
+			void deleteFile(const Request& request, Response& response, const std::string& filePath);
 	};
 
 } /* namespace http */

--- a/include/http/GetHandler.hpp
+++ b/include/http/GetHandler.hpp
@@ -23,8 +23,10 @@ namespace http {
 		private:
 			void getFilePath(const config::Location& location, const std::string& filePath, std::string& target);
 
+			std::streamsize getBufferSize() const { return BUFFER_SIZE; }
+
 		private:
-			static const std::streamsize GET_BUFFER_SIZE = 16384; // 16 KB
+			static const std::streamsize BUFFER_SIZE = 16384; // 16 KB
 			std::ifstream m_fileStream;
 	};
 

--- a/include/http/GetHandler.hpp
+++ b/include/http/GetHandler.hpp
@@ -16,10 +16,15 @@ namespace http {
 			~GetHandler();
 
 			void handle(const Request& request, Response& response);
+			void openFile(const Request& request, Response& response);
+			void readFile(Response& response);
 			void reset();
 
 		private:
 			void getFilePath(const config::Location& location, const std::string& filePath, std::string& target);
+
+		private:
+			static const std::streamsize GET_BUFFER_SIZE = 16384; // 16 KB
 			std::ifstream m_fileStream;
 	};
 

--- a/include/http/PostHandler.hpp
+++ b/include/http/PostHandler.hpp
@@ -14,6 +14,15 @@ namespace http {
 			~PostHandler();
 
 			void handle(const Request& request, Response& response);
+
+			void reset();
+
+		private:
+			void createFile(const Request& request);
+
+		private:
+			std::ofstream m_fileStream;
+			size_t m_bytesWritten;
 	};
 
 } /* namespace http */

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -45,6 +45,7 @@ namespace http {
 			void setLocation(const config::Location* location);
 
 			bool hasHeader(const std::string& key) const;
+			bool needsSafePath() const;
 
 			void appendToBody(const char* data, std::size_t len);
 

--- a/include/http/Request.hpp
+++ b/include/http/Request.hpp
@@ -34,6 +34,7 @@ namespace http {
 			StatusCode getStatusCode() const;
 			bool hasError() const;
 			const config::Location* getLocation() const;
+			FileType getFileType() const;
 
 			void setType(RequestType type);
 			void setMethod(const char* method, std::size_t len);
@@ -43,6 +44,7 @@ namespace http {
 			void setHeader(const char* key, std::size_t keyLen, const char* value, std::size_t valueLen);
 			void setStatusCode(StatusCode statusCode);
 			void setLocation(const config::Location* location);
+			void setFileType(FileType type);
 
 			bool hasHeader(const std::string& key) const;
 			bool needsSafePath() const;
@@ -69,6 +71,7 @@ namespace http {
 			http::StatusCode m_statusCode;
 			Uri m_uri;
 			const config::Location* m_requestedLocation;
+			FileType m_fileType;
 	};
 
 } /* namespace http */

--- a/include/http/RequestProcessor.hpp
+++ b/include/http/RequestProcessor.hpp
@@ -24,6 +24,7 @@ namespace http {
 
 			// TODO: remove testing function
 			int testParseURI(const std::string& uri, int mode);
+			void log(const std::string& msg, shared::LogLevel level, const Request& request);
 
 			Response* releaseResponse();
 			bool isDone() const;
@@ -38,6 +39,7 @@ namespace http {
 			std::map<Method, ARequestHandler*> m_handlers;
 			Router& m_router;
 			bool m_done;
+			shared::Logger m_logger;
 	};
 
 } /* namespace http */

--- a/include/http/Response.hpp
+++ b/include/http/Response.hpp
@@ -26,7 +26,7 @@ namespace http {
 			void setStatusCode(StatusCode statusCode);
 			void setBody(const std::string& body);
 			void setHeader(const std::string& key, const std::string& value);
-			void appendToBody(const std::string& bodySegment);
+			void appendToBody(const char* data, std::size_t len);
 
 			shared::Buffer<RESPONSE_BUFFER_SIZE>& getData();
 			StatusCode getStatusCode() const;

--- a/include/http/Response.hpp
+++ b/include/http/Response.hpp
@@ -28,16 +28,21 @@ namespace http {
 			void setHeader(const std::string& key, const std::string& value);
 			void appendToBody(const char* data, std::size_t len);
 
-			shared::Buffer<RESPONSE_BUFFER_SIZE>& getData();
+			std::string& getData();
 			StatusCode getStatusCode() const;
 			const std::string& getBody() const;
+			std::size_t getReadPos() const;
+
+			void advanceReadPos(std::size_t n);
+			bool eof() const;
 
 		private:
 			StatusCode m_statusCode;
 			std::map<std::string, std::vector<std::string> > m_headers;
 			std::string m_body;
+			std::size_t m_readPos;
 
-			shared::Buffer<RESPONSE_BUFFER_SIZE> m_data;
+			std::string m_data;
 	};
 
 } /* namespace http */

--- a/src/http/DeleteHandler.cpp
+++ b/src/http/DeleteHandler.cpp
@@ -8,13 +8,29 @@ namespace http {
 	 * @brief Constructs a new DeleteHandler object.
 	 */
 	DeleteHandler::DeleteHandler(Router& router)
-		: ARequestHandler(router) {
-	}
+		: ARequestHandler(router) {}
 
 	/**
 	 * @brief Destroys the DeleteHandler object.
 	 */
-	DeleteHandler::~DeleteHandler() {
+	DeleteHandler::~DeleteHandler() {}
+
+	void DeleteHandler::deleteFile(Response& response, const std::string& filePath) {
+		FileType fileType = m_router.checkFileType(filePath);
+
+		if (fileType == _NOT_FOUND) { // TODO: replace with actual file name
+			throw http::exception(NOT_FOUND, "DELETE: File doesn't exist");
+		}
+		if (fileType == DIRECTORY) {
+			throw http::exception(FORBIDDEN, "DELETE: Expected file; received directory");
+		}
+		if (std::remove(filePath.c_str()) != 0) { // unlink the file
+			throw http::exception(FORBIDDEN, "DELETE: File could not be removed");
+		}
+
+		response.setStatusCode(NO_CONTENT);
+		response.setHeader("Content-Length", "0");
+		m_state = DONE;
 	}
 
 	// in GET, there should be a file name in the path
@@ -22,23 +38,18 @@ namespace http {
 	// or return 200 OK if there's information in the body
 	// i.e. a html page saying "file /foo/bar.baz was deleted"
 	void DeleteHandler::handle(const Request& request, Response& response) {
-		try {
-			FileType fileType = m_router.checkFileType(request.getUri().safeAbsolutePath);
-			if (fileType == _NOT_FOUND) { // TODO: replace with actual file name
-				throw http::exception(NOT_FOUND, "DELETE: File doesn't exist");
+		switch (m_state) {
+			case PENDING:
+			case PROCESSING: {
+				return deleteFile(response, request.getUri().safeAbsolutePath);
 			}
-			if (fileType == DIRECTORY) {
-				throw http::exception(FORBIDDEN, "DELETE: Expected file; received directory");
+
+			case DONE: {
+				return;
 			}
-			if (std::remove(request.getUri().safeAbsolutePath.c_str()) != 0) { // unlink the file
-				throw http::exception(FORBIDDEN, "DELETE: File could not be removed");
-			}
-			response.setStatusCode(NO_CONTENT);
-			response.setHeader("Content-Length", "0");
-		} catch (const http::exception& e) {
-			std::cout << "FUCK, " << e.getMessage() << std::endl;
-			response.setStatusCode(e.getStatusCode());
-			return handleError(response);
+
+			default:
+				throw http::exception(INTERNAL_SERVER_ERROR, "DeleteHandler: Invalid Handler State");
 		}
 	}
 

--- a/src/http/DeleteHandler.cpp
+++ b/src/http/DeleteHandler.cpp
@@ -15,8 +15,8 @@ namespace http {
 	 */
 	DeleteHandler::~DeleteHandler() {}
 
-	void DeleteHandler::deleteFile(Response& response, const std::string& filePath) {
-		FileType fileType = m_router.checkFileType(filePath);
+	void DeleteHandler::deleteFile(const Request& request, Response& response, const std::string& filePath) {
+		FileType fileType = request.getFileType();
 
 		if (fileType == _NOT_FOUND) { // TODO: replace with actual file name
 			throw http::exception(NOT_FOUND, "DELETE: File doesn't exist");
@@ -41,7 +41,7 @@ namespace http {
 		switch (m_state) {
 			case PENDING:
 			case PROCESSING: {
-				return deleteFile(response, request.getUri().safeAbsolutePath);
+				return deleteFile(request, response, request.getUri().safeAbsolutePath);
 			}
 
 			case DONE: {

--- a/src/http/GetHandler.cpp
+++ b/src/http/GetHandler.cpp
@@ -28,7 +28,7 @@ namespace http {
 
 	void GetHandler::openFile(const Request& request, Response& response) {
 		const config::Location& location = *request.getLocation();
-		FileType fileType = m_router.checkFileType(request.getUri().safeAbsolutePath);
+		FileType fileType = request.getFileType();
 
 		if (fileType == _NOT_FOUND) {
 			throw http::exception(NOT_FOUND, "GET: File doesn't exist");
@@ -63,22 +63,15 @@ namespace http {
 	}
 
 	void GetHandler::readFile(Response& response) {
-		std::vector<char> buffer(GET_BUFFER_SIZE);
+		std::vector<char> buffer(this->getBufferSize());
 
-		std::cout << " state is " << m_fileStream.good() << std::endl;
-		m_fileStream.read(buffer.data(), GET_BUFFER_SIZE);
-		std::cout << " state is " << m_fileStream.good() << m_fileStream.eof() << std::endl;
+		m_fileStream.read(buffer.data(), this->getBufferSize());
 		std::streamsize bytesRead = m_fileStream.gcount();
 
-		std::cout << "read " << bytesRead << " bytes " << std::endl;
 		if (bytesRead > 0) {
-			// std::cout << "appending:" << std::endl;
-			// std::cout << buffer << std::endl;
 			response.appendToBody(buffer.data(), bytesRead);
-			return; // more to read
+			return;
 		}
-		std::cout << "Read complete, preparing for sendoff. Body:" << std::endl;
-		std::cout << response.getBody() << std::endl;
 
 		m_fileStream.close();
 		response.setHeader("Content-Length", shared::string::to_string(response.getBody().size()));

--- a/src/http/PostHandler.cpp
+++ b/src/http/PostHandler.cpp
@@ -11,55 +11,94 @@ namespace http {
 	 * @brief Constructs a new PostHandler object.
 	 */
 	PostHandler::PostHandler(Router& router)
-		: ARequestHandler(router) {}
+		: ARequestHandler(router)
+		, m_fileStream()
+		, m_bytesWritten(0) {}
 
 	/**
 	 * @brief Destroys the PostHandler object.
 	 */
 	PostHandler::~PostHandler() {}
 
+	void PostHandler::createFile(const Request& request) {
+		FileType fileType = m_router.checkFileType(request.getUri().safeAbsolutePath);
+
+		if (fileType == _NOT_FOUND) {
+			throw http::exception(FORBIDDEN, "POST: Directory could not be found");
+		}
+		if (fileType == FILE) {
+			throw http::exception(FORBIDDEN, "POST: Expected directory; received file");
+		}
+		if (!request.getLocation()->acceptsFileUpload()) {
+			throw http::exception(FORBIDDEN, "Location does not accept file uploads (no POST)");
+		}
+
+		std::string fileName;
+
+		if (request.hasHeader("x-cool-filename")) {
+			const std::vector<std::string>& filenameHeader = request.getHeader("x-cool-filename");
+			if (!filenameHeader.empty() && !filenameHeader.at(0).empty()) {
+				fileName = filenameHeader.at(0);
+			} else {
+				time_t now = time(NULL);
+				std::cout << "Filename empty! Falling back to default..." << std::endl;
+				fileName = shared::string::fromNum(static_cast<int>(now)) + "_upload.dat";
+			}
+		}
+
+		std::string absoluteFilePath = request.getUri().safeAbsolutePath + "/" + fileName; // TODO: replace with actual file name
+
+		if (shared::file::fileExists(absoluteFilePath)) {
+			throw http::exception(CONFLICT, "POST: A file with this name already exists");
+		}
+		m_fileStream.open(absoluteFilePath.c_str(), std::ios::binary);
+		m_state = PROCESSING;
+	}
+
 	// in POST, there should be no file name in the path
+	// TODO: currently returns 403 forbidden if the file
+	// in the path exists and 404 not found if it doesn't
 	void PostHandler::handle(const Request& request, Response& response) {
-		try {
-			FileType fileType = m_router.checkFileType(request.getUri().safeAbsolutePath);
-			if (fileType == _NOT_FOUND) {
-				throw http::exception(FORBIDDEN, "POST: Directory could not be found");
+		switch (m_state) {
+			case PENDING: {
+				return createFile(request);
 			}
-			if (fileType == FILE) {
-				throw http::exception(FORBIDDEN, "POST: Expected directory; received file");
-			}
-			if (!request.getLocation()->acceptsFileUpload()) {
-				throw http::exception(FORBIDDEN, "Location does not accept file uploads (no POST)");
-			}
-			std::string fileName = "uploaded.dat";
-			if (request.hasHeader("x-cool-filename")) {
-				const std::vector<std::string>& filenameHeader = request.getHeader("x-cool-filename");
-				if (!filenameHeader.empty() && !filenameHeader.at(0).empty()) {
-					std::cout << "Filename header: " << filenameHeader.at(0) << std::endl;
-					fileName = filenameHeader.at(0);
-				} else {
-					std::cout << "Filename empty! Falling back to default..." << std::endl;
+
+			case PROCESSING: {
+				const std::string& requestBody = request.getBody();
+
+				try {
+					size_t bytesToWrite = std::min(requestBody.size() - m_bytesWritten, getChunkSize());
+
+					m_fileStream.write(requestBody.data() + m_bytesWritten, bytesToWrite); // TODO: verify whether this could break & if so, what error to throw
+					m_bytesWritten += bytesToWrite;
+					std::cout << "Total bytes written now " << m_bytesWritten << std::endl;
+				} catch (std::exception& e) {
+					std::cerr << "PostHandler::handle(): " << e.what() << std::endl;
+					m_fileStream.close();
+					throw http::exception(INTERNAL_SERVER_ERROR, "PostHandler: Failure during write() occurred");
+				}
+				if (m_bytesWritten == requestBody.size()) {
+					m_fileStream.close();
+					response.setStatusCode(CREATED);
+					response.setHeader("Content-Length", "0");
+					m_state = DONE;
 				}
 			}
-			std::string absoluteFilePath = request.getUri().safeAbsolutePath + "/" + fileName; // TODO: replace with actual file name
-			std::cout << "Checking path for posted file: " << absoluteFilePath << std::endl;
-			if (shared::file::fileExists(absoluteFilePath)) {
-				throw http::exception(CONFLICT, "POST: A file with this name already exists");
-			}
-			std::cout << "Saving POSTed file as " << absoluteFilePath << std::endl;
-			std::ofstream outFile(absoluteFilePath.c_str(), std::ios::binary);
-			if (!outFile.is_open()) {
-				throw http::exception(FORBIDDEN, "POST: File couldn't be opened");
-			}
-			outFile.write(request.getBody().data(), request.getBody().size()); // TODO: verify whether this could break & if so, what error to throw
-			outFile.close();
-			response.setStatusCode(CREATED);
-			response.setHeader("Content-Length", "0");
-		} catch (const http::exception& e) {
-			std::cout << "DANG, " << e.getMessage() << std::endl;
-			response.setStatusCode(e.getStatusCode());
-			return handleError(response);
+
+			case DONE:
+				return;
+
+			default:
+				throw http::exception(INTERNAL_SERVER_ERROR, "PostHandler: Invalid Handler State");
 		}
+	}
+
+	void PostHandler::reset() {
+		this->ARequestHandler::reset();
+		m_fileStream.close();
+		m_fileStream.clear();
+		m_bytesWritten = 0;
 	}
 
 } /* namespace http */

--- a/src/http/PostHandler.cpp
+++ b/src/http/PostHandler.cpp
@@ -21,7 +21,7 @@ namespace http {
 	PostHandler::~PostHandler() {}
 
 	void PostHandler::createFile(const Request& request) {
-		FileType fileType = m_router.checkFileType(request.getUri().safeAbsolutePath);
+		FileType fileType = request.getFileType();
 
 		if (fileType == _NOT_FOUND) {
 			throw http::exception(FORBIDDEN, "POST: Directory could not be found");
@@ -72,7 +72,6 @@ namespace http {
 
 					m_fileStream.write(requestBody.data() + m_bytesWritten, bytesToWrite); // TODO: verify whether this could break & if so, what error to throw
 					m_bytesWritten += bytesToWrite;
-					std::cout << "Total bytes written now " << m_bytesWritten << std::endl;
 				} catch (std::exception& e) {
 					std::cerr << "PostHandler::handle(): " << e.what() << std::endl;
 					m_fileStream.close();

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -17,7 +17,8 @@ namespace http {
 		, m_version(HTTP_VERSION)
 		, m_statusCode(OK)
 		, m_uri()
-		, m_requestedLocation(NULL) {
+		, m_requestedLocation(NULL)
+		, m_fileType(FILE) {
 	}
 
 	/**
@@ -93,6 +94,8 @@ namespace http {
 
 	const config::Location* Request::getLocation() const { return m_requestedLocation; }
 
+	FileType Request::getFileType() const { return m_fileType; }
+
 	bool Request::hasError() const {
 		return m_statusCode >= 400;
 	}
@@ -123,6 +126,8 @@ namespace http {
 	void Request::setStatusCode(StatusCode statusCode) { m_statusCode = statusCode; }
 
 	void Request::setLocation(const config::Location* location) { m_requestedLocation = location; }
+
+	void Request::setFileType(FileType type) { m_fileType = type; }
 
 	void Request::validateUriRaw(const char* uri, std::size_t len) {
 		if (len == 0 || uri == NULL) {

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -61,6 +61,10 @@ namespace http {
 		return m_headers.find(key) != m_headers.end();
 	}
 
+	bool Request::needsSafePath() const {
+		return m_uri.safeAbsolutePath.empty();
+	}
+
 	void Request::appendToBody(const char* data, std::size_t len) {
 		m_body.append(data, len);
 	}

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -451,7 +451,7 @@ namespace http {
 	}
 
 	bool RequestParser::hasError() const {
-		return m_state & ERROR;
+		return m_state == ERROR;
 	}
 
 	shared::Buffer<REQUEST_BUFFER_SIZE>& RequestParser::getWriteBuffer() {

--- a/src/http/RequestProcessor.cpp
+++ b/src/http/RequestProcessor.cpp
@@ -13,8 +13,10 @@ namespace http {
 	 */
 	RequestProcessor::RequestProcessor(Router& router)
 		: m_res(NULL)
+		, m_handlers()
 		, m_router(router)
-		, m_done(false) {
+		, m_done(false)
+		, m_logger() {
 		m_handlers.insert(std::make_pair(GET, new GetHandler(m_router)));
 		m_handlers.insert(std::make_pair(POST, new PostHandler(m_router)));
 		m_handlers.insert(std::make_pair(DELETE, new DeleteHandler(m_router)));
@@ -28,6 +30,13 @@ namespace http {
 			delete it->second;
 		}
 		delete m_res;
+	}
+
+	void RequestProcessor::log(const std::string& msg, shared::LogLevel level, const Request& request) {
+		std::string formatted = "[" + getMethodString(request.getMethod()) + " " + request.getUri().path + "] ";
+
+		formatted += msg;
+		m_logger.log(formatted, level);
 	}
 
 	void RequestProcessor::handleError(Response* response) {
@@ -47,11 +56,11 @@ namespace http {
 		const config::Location& serverRoot = m_router.getServerRoot();
 		std::pair<std::string, const config::Location*> location = m_router.routeToPath(req.getUri().pathSegments, serverRoot);
 
-		std::cout << "path returned: " << location.first << std::endl;
+		this->log("routeToSafePath returned: " + location.first, shared::DEBUG, req);
 
-		FileType fileType = Router::checkFileType(location.first);
+		req.setFileType(Router::checkFileType(location.first));
 
-		if (fileType == _NOT_FOUND) {
+		if (req.getFileType() == _NOT_FOUND) {
 			throw http::exception(NOT_FOUND, "File or directory not found");
 		}
 		if (!location.second->allowedMethods.empty() && location.second->allowedMethods.find(req.getMethod()) == location.second->allowedMethods.end()) { // TODO: probably shouldn't check this here, causes files that
@@ -78,7 +87,7 @@ namespace http {
 			handler->handle(req, *m_res);
 			m_done = handler->isComplete();
 		} catch (const http::exception& e) {
-			std::cout << "CRAP, " << e.getMessage() << "; " << e.getStatusCode() << "; handling error now" << std::endl;
+			this->log("CRAP, " + e.getMessage() + "; handling error now", shared::ERROR, req);
 			m_res->setStatusCode(e.getStatusCode());
 			handleError(m_res);
 			m_done = true;

--- a/src/http/RequestProcessor.cpp
+++ b/src/http/RequestProcessor.cpp
@@ -66,18 +66,25 @@ namespace http {
 		if (!m_res) {
 			m_res = new Response();
 		}
+		ARequestHandler* handler = m_handlers[req.getMethod()];
+
 		try {
 			if (req.hasError()) {
 				throw http::exception(req.getStatusCode());
 			}
-			routeToSafePath(req);
-			m_handlers[req.getMethod()]->handle(req, *m_res);
-			m_done = m_handlers[req.getMethod()]->isComplete();
+			if (req.needsSafePath()) {
+				routeToSafePath(req);
+			}
+			handler->handle(req, *m_res);
+			m_done = handler->isComplete();
 		} catch (const http::exception& e) {
 			std::cout << "CRAP, " << e.getMessage() << "; " << e.getStatusCode() << "; handling error now" << std::endl;
 			m_res->setStatusCode(e.getStatusCode());
 			handleError(m_res);
 			m_done = true;
+		}
+		if (m_done) {
+			handler->reset();
 		}
 	}
 

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -13,6 +13,7 @@ namespace http {
 		: m_statusCode(OK)
 		, m_headers()
 		, m_body()
+		, m_readPos(0)
 		, m_data() {
 	}
 
@@ -31,8 +32,6 @@ namespace http {
 	}
 
 	void Response::serialize() {
-		m_data.reset();
-
 		std::string statusLine = HTTP_VERSION + " " +
 			shared::string::to_string(static_cast<int>(m_statusCode)) + " " +
 			getStatusMessage(m_statusCode) + CRLF;
@@ -64,11 +63,22 @@ namespace http {
 
 	void Response::appendToBody(const char* data, std::size_t len) { m_body.append(data, len); }
 
-	shared::Buffer<RESPONSE_BUFFER_SIZE>& Response::getData() { return m_data; }
+	std::string& Response::getData() { return m_data; }
 
 	StatusCode Response::getStatusCode() const { return m_statusCode; }
 
 	const std::string& Response::getBody() const { return m_body; }
+
+	std::size_t Response::getReadPos() const { return m_readPos; }
+
+	bool Response::eof() const { return m_readPos >= m_data.size(); }
+
+	void Response::advanceReadPos(std::size_t n) {
+		m_readPos += n;
+		if (m_readPos > m_data.size()) {
+			m_readPos = m_data.size();
+		}
+	}
 
 
 } /* namespace http */

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -62,7 +62,7 @@ namespace http {
 
 	void Response::setHeader(const std::string& key, const std::string& value) { m_headers[key].push_back(value); }
 
-	void Response::appendToBody(const std::string& bodySegment) { m_body += bodySegment; }
+	void Response::appendToBody(const char* data, std::size_t len) { m_body.append(data, len); }
 
 	shared::Buffer<RESPONSE_BUFFER_SIZE>& Response::getData() { return m_data; }
 

--- a/src/http/Router.cpp
+++ b/src/http/Router.cpp
@@ -88,9 +88,8 @@ namespace http {
 			return std::make_pair(currentLocation.precalculatedAbsolutePath, &currentLocation); // TODO: I think this doesn't set the root path properly yet, does it?
 		}
 		for (std::vector<config::Location>::const_iterator loc = currentLocation.locations.begin(); loc != currentLocation.locations.end(); ++loc) {
-			if (!loc->pathAsTokens.empty() && loc->pathAsTokens[0] == pathToMatch[depth]) {					// TODO: breaks if location is '/' -> check if (!loc->path.empty())
-				std::cout << "Location matched: " << loc->pathAsTokens[0] << ", going deeper" << std::endl; // TODO: check the codebase for other possibly unsafe garbage when a vector<string> is empty
-				return routeToPath(pathToMatch, *loc, redirects, depth + 1);								// use nearest parent
+			if (!loc->pathAsTokens.empty() && loc->pathAsTokens[0] == pathToMatch[depth]) { // TODO: breaks if location is '/' -> check if (!loc->path.empty())
+				return routeToPath(pathToMatch, *loc, redirects, depth + 1);				// use nearest parent
 			}
 		}
 		// no location matched

--- a/src/http/Router.cpp
+++ b/src/http/Router.cpp
@@ -37,7 +37,6 @@ namespace http {
 	//
 
 	FileType Router::checkFileType(const std::string& absolutePath) {
-		std::cout << "Checking FileType for path: " << absolutePath << std::endl;
 		struct stat statBuf;
 		if (stat(absolutePath.c_str(), &statBuf) != 0) {
 			return _NOT_FOUND; // Path does not exist
@@ -84,8 +83,7 @@ namespace http {
 			return routeToPath(currentLocation.redirectUriAsTokens, m_rootLocation, redirects + 1, 0); // TODO: invalid, this would then always return serverRoot's route
 		}																							   // TODO: how the frick do we solve this?
 		if (depth >= pathToMatch.size()) {															   // TODO: what about files?
-			std::cout << "Reached end of path" << std::endl;
-			return std::make_pair(currentLocation.precalculatedAbsolutePath, &currentLocation); // TODO: I think this doesn't set the root path properly yet, does it?
+			return std::make_pair(currentLocation.precalculatedAbsolutePath, &currentLocation);		   // TODO: I think this doesn't set the root path properly yet, does it?
 		}
 		for (std::vector<config::Location>::const_iterator loc = currentLocation.locations.begin(); loc != currentLocation.locations.end(); ++loc) {
 			if (!loc->pathAsTokens.empty() && loc->pathAsTokens[0] == pathToMatch[depth]) { // TODO: breaks if location is '/' -> check if (!loc->path.empty())


### PR DESCRIPTION
### Description

This PR includes major changes to the RequestProcesser and all RequestHandlers. Writes to and reads from disk are now done in chunks, avoiding any potential blocking.

### Type of Change

- [x] New feature

### How to Test

Send one or several concurrent requests, and try POSTing and then GETting a larger file, e.g. a 5MB image.

### Todo

- [x] Generate and send an error response when a RequestHandler fails. Currently, we drop the connection straight away.