### PR TITLE
refactor(configParser): reduce duplicate logic

### DIFF
--- a/config/config.conf
+++ b/config/config.conf
@@ -12,6 +12,10 @@ server {
 	max_header_count 69;
 	max_header_value_count 69;
 	max_header_name_length 69;
+	# connection_timeout 60; # timeout in seconds
+	# cgi_timeout 60; # cgi script timeout in seconds
+	# error_page 404 e404.html e40xd.html;
+	# error_page 405 e405.html e40haha.html;
 
 	# todo: PATHS TO VALIDATE AGAINST CONTAINING RELATIVE PATH (/.. or /. segments)
 	# root, data_dir, location, index (should only be files), return

--- a/include/config/Parser.hpp
+++ b/include/config/Parser.hpp
@@ -42,6 +42,9 @@ namespace config {
 			std::size_t m_readPos;
 			static bool m_readingFile;
 
+			std::map<std::string, http::Method> m_implementedMethods;
+			std::set<std::string> m_autoIndexAllowedValues;
+
 			static const std::string WHITESPACE;
 
 		private:
@@ -79,33 +82,28 @@ namespace config {
 			void expectServerBlock() throw(parse_exception);
 			void expectLocationBlock(LocationConfig& parentLocation) throw(parse_exception);
 
-			void processServerValue(const std::string& value, CommandType type, ServerConfig& server);
-			void processLocationValue(const std::string& value, CommandType type, LocationConfig& location);
+			void processServerValue(const std::string& key, const std::string& value, CommandType type, ServerConfig& server) throw(parse_exception);
+			void processLocationValue(const std::string& key, const std::string& value, CommandType type, LocationConfig& location) throw(parse_exception);
 
 			static const std::map<std::string, CommandType>& locationDirectives();
 			static const std::map<std::string, CommandType>& serverDirectives();
 
 		private:
+			// ------------------------  generic parsers  ------------------- //
+			void parseIntegerValue(const std::string& key, const std::string& value, unsigned long& destination) throw(parse_exception);
+			void parsePathValue(const std::string& key, const std::string& value, std::string& destination) throw(parse_exception);
 			// ------------------------  server parsers  -------------------- //
-			void parseListen(const std::string& value, ServerConfig& server);
-			void parseClientMaxBodySize(const std::string& value, ServerConfig& server);
-			void parseMaxHeaderValueLength(const std::string& value, ServerConfig& server);
-			void parseMaxHeaderCount(const std::string& value, ServerConfig& server);
-			void parseMaxHeaderValueCount(const std::string& value, ServerConfig& server);
-			void parseMaxHeaderNameLength(const std::string& value, ServerConfig& server);
-			void parseDataDir(const std::string& value, ServerConfig& server);
-			void parseServerName(const std::string& value, ServerConfig& server);
+			void parseListen(const std::string& value, ServerConfig& server) throw(parse_exception);
+			void parseServerName(const std::string& value, ServerConfig& server) throw(parse_exception);
 
-			uint32_t parseIpAddress(const std::string& host);
+			uint32_t parseIpAddress(const std::string& host) throw(parse_exception);
 			void assignAbsolutePaths(ServerConfig& server, LocationConfig& parentLocation) throw(parse_exception);
 
 			// ------------------------  location parsers  ------------------ //
-			void parseRoot(const std::string& value, LocationConfig& location);
-			void parseReturn(const std::string& value, LocationConfig& location);
-			void parseLimitExcept(const std::string& value, LocationConfig& location);
-			void parseUploadDir(const std::string& value, LocationConfig& location);
-			void parseIndex(const std::string& value, LocationConfig& location);
-			void parseAutoindex(const std::string& value, LocationConfig& location);
+			void parseReturn(const std::string& value, LocationConfig& location) throw(parse_exception);
+			void parseLimitExcept(const std::string& value, LocationConfig& location) throw(parse_exception);
+			void parseIndex(const std::string& value, LocationConfig& location) throw(parse_exception);
+			void parseAutoindex(const std::string& value, LocationConfig& location) throw(parse_exception);
 	};
 
 } /* namespace config */

--- a/src/core/AcceptEventHandler.cpp
+++ b/src/core/AcceptEventHandler.cpp
@@ -14,7 +14,7 @@ namespace core {
 	}
 
 	io::EventResult AcceptEventHandler::onReadable(int32_t) {
-		LOG_CONTEXT("read event | server: " + m_vServer.getVirtualServerInfo());
+		LOG_CONTEXT("read event  | server: " + m_vServer.getVirtualServerInfo());
 
 		while (Connection* conn = m_vServer.acceptNewConnection()) {
 			m_dispatcher.registerHandler(conn->getSocket().getFd(),

--- a/src/core/ConnectionEventHandler.cpp
+++ b/src/core/ConnectionEventHandler.cpp
@@ -38,7 +38,7 @@ namespace core {
 	}
 
 	io::EventResult ConnectionEventHandler::onReadable(int32_t) {
-		LOG_CONTEXT("read event | server: " + m_vServer.getVirtualServerInfo() +
+		LOG_CONTEXT("read event  | server: " + m_vServer.getVirtualServerInfo() +
 					" | connection: " + m_connection.getConnectionInfo());
 
 		shared::container::Buffer<http::RequestParser::BUFFER_SIZE>& buffer = m_requestParser.getReadBuffer();


### PR DESCRIPTION
### Description

This PR simplifies some of the config parser, providing generic functions for parsing path and integer values. Additionally, it adds missing throw() specifiers to each of the parser's methods.