### PR TITLE
fix/cgi/exit

### DIFF
--- a/include/core/AcceptEventHandler.hpp
+++ b/include/core/AcceptEventHandler.hpp
@@ -16,6 +16,8 @@ namespace core {
 
 			virtual io::EventResult onWriteable(int32_t fd);
 
+			virtual io::EventResult onHangup(int32_t fd);
+
 			virtual io::EventResult onError(int32_t fd);
 
 		private:

--- a/include/core/CGIEventHandler.hpp
+++ b/include/core/CGIEventHandler.hpp
@@ -15,6 +15,8 @@ namespace core {
 
 			io::EventResult onWriteable(int32_t fd);
 
+			io::EventResult onHangup(int32_t fd);
+
 			io::EventResult onError(int32_t fd);
 
 		private:

--- a/include/core/ConnectionEventHandler.hpp
+++ b/include/core/ConnectionEventHandler.hpp
@@ -28,6 +28,8 @@ namespace core {
 
 			virtual io::EventResult onWriteable(int32_t fd);
 
+			virtual io::EventResult onHangup(int32_t fd);
+
 			virtual io::EventResult onError(int32_t fd);
 
 		private:

--- a/include/io/AMultiplexer.hpp
+++ b/include/io/AMultiplexer.hpp
@@ -19,7 +19,8 @@ namespace io {
 				EVENT_READ = 0x1,
 				EVENT_WRITE = 0x2,
 				EVENT_ERROR = 0x4,
-				EVENT_ALL = EVENT_READ | EVENT_WRITE | EVENT_ERROR,
+				EVENT_HANGUP = 0x8,
+				EVENT_ALL = EVENT_READ | EVENT_WRITE | EVENT_ERROR | EVENT_HANGUP,
 			};
 
 			struct Event {

--- a/include/io/Dispatcher.hpp
+++ b/include/io/Dispatcher.hpp
@@ -18,6 +18,8 @@ namespace io {
 			int32_t dispatch(int32_t timeoutMs = AMultiplexer::TIMEOUT_INFINITE);
 			void close();
 
+			bool isRegistered(int32_t fd) const;
+
 			void cleanup();
 
 		private:

--- a/include/io/IEventHandler.hpp
+++ b/include/io/IEventHandler.hpp
@@ -19,6 +19,8 @@ namespace io {
 
 			virtual EventResult onWriteable(int32_t fd) = 0;
 
+			virtual EventResult onHangup(int32_t fd) = 0;
+
 			virtual EventResult onError(int32_t fd) = 0;
 	};
 

--- a/src/core/CGIEventHandler.cpp
+++ b/src/core/CGIEventHandler.cpp
@@ -66,6 +66,12 @@ namespace core {
 		return io::KEEP_MONITORING;
 	}
 
+	io::EventResult CGIEventHandler::onHangup(int32_t) {
+		LOG_ERROR("IO event hangup on CGI handler");
+		m_processor.notifyIOError();
+		return io::UNREGISTER;
+	}
+
 	io::EventResult CGIEventHandler::onError(int32_t) {
 		LOG_ERROR("IO event error on CGI handler");
 		m_processor.notifyIOError();

--- a/src/core/ConnectionEventHandler.cpp
+++ b/src/core/ConnectionEventHandler.cpp
@@ -109,6 +109,12 @@ namespace core {
 		return io::KEEP_MONITORING;
 	}
 
+	io::EventResult ConnectionEventHandler::onHangup(int32_t) {
+		LOG_ERROR("hangup event | virtual server: " + m_vServer.getVirtualServerInfo() +
+				  " | connection: " + m_connection.getConnectionInfo());
+		return io::UNREGISTER;
+	}
+
 	io::EventResult ConnectionEventHandler::onError(int32_t) {
 		LOG_ERROR("error event | virtual server: " + m_vServer.getVirtualServerInfo() +
 				  " | connection: " + m_connection.getConnectionInfo() + " multiplexing error");

--- a/src/io/EpollMultiplexer.cpp
+++ b/src/io/EpollMultiplexer.cpp
@@ -27,6 +27,10 @@ namespace io {
 	}
 
 	void EpollMultiplexer::add(int32_t fd, uint32_t events) {
+		if (m_fd == -1) {
+			return;
+		}
+
 		struct epoll_event ev;
 		std::memset(&ev, 0, sizeof(ev));
 		ev.events = convertToEpollEvents(events);
@@ -40,6 +44,10 @@ namespace io {
 	}
 
 	void EpollMultiplexer::modify(int32_t fd, uint32_t events) {
+		if (m_fd == -1) {
+			return;
+		}
+
 		EventMap::iterator it = m_registeredEvents.find(fd);
 		if (it == m_registeredEvents.end()) {
 			throw std::runtime_error("failed to modify epoll event: fd not registered");
@@ -61,6 +69,10 @@ namespace io {
 	}
 
 	void EpollMultiplexer::remove(int32_t fd) {
+		if (m_fd == -1) {
+			return;
+		}
+
 		EventMap::iterator it = m_registeredEvents.find(fd);
 		if (it == m_registeredEvents.end()) {
 			return;
@@ -109,6 +121,9 @@ namespace io {
 		if (events & EVENT_ERROR) {
 			epollEvents |= EPOLLERR;
 		}
+		if (events & EVENT_HANGUP) {
+			epollEvents |= EPOLLHUP;
+		}
 
 		return epollEvents;
 	}
@@ -124,6 +139,9 @@ namespace io {
 		}
 		if (epollEvents & EPOLLERR) {
 			events |= EVENT_ERROR;
+		}
+		if (epollEvents & EPOLLHUP) {
+			events |= EVENT_HANGUP;
 		}
 
 		return events;

--- a/src/io/KqueueMultiplexer.cpp
+++ b/src/io/KqueueMultiplexer.cpp
@@ -24,6 +24,10 @@ namespace io {
 	}
 
 	void KqueueMultiplexer::add(int32_t fd, uint32_t events) {
+		if (m_fd == -1) {
+			return;
+		}
+
 		uint32_t nChanges = 0;
 		struct kevent changes[2];
 		EV_SET(&changes[0], 0, 0, 0, 0, 0, NULL);
@@ -46,6 +50,10 @@ namespace io {
 	}
 
 	void KqueueMultiplexer::modify(int32_t fd, uint32_t events) {
+		if (m_fd == -1) {
+			return;
+		}
+
 		EventMap::iterator it = m_registeredEvents.find(fd);
 		if (it == m_registeredEvents.end()) {
 			throw std::runtime_error("fd not registered");
@@ -83,6 +91,10 @@ namespace io {
 	}
 
 	void KqueueMultiplexer::remove(int32_t fd) {
+		if (m_fd == -1) {
+			return;
+		}
+
 		EventMap::iterator it = m_registeredEvents.find(fd);
 		if (it == m_registeredEvents.end()) {
 			return;
@@ -153,6 +165,9 @@ namespace io {
 		}
 		if (flags & EV_ERROR) {
 			events |= EVENT_ERROR;
+		}
+		if (flags & EV_EOF) {
+			events |= EVENT_HANGUP;
 		}
 
 		return events;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,8 @@ int main(int argc, char* argv[]) {
 	} catch (const std::exception& e) {
 		LOG_FATAL(e.what());
 		return 1;
+	} catch (...) {
+		return 1;
 	}
 	return 0;
 }


### PR DESCRIPTION
- unwinding the stack on child process failure
- suppressing multiplexer errors from child as we close all of the registered fds including the multiplexer fd which coused a lot of noice in the logs.
- also monitoring for hangup now so we get notified when the child DIES

Closes #69 