### PR TITLE
feat: import router

### DIFF
--- a/include/config/LocationConfig.hpp
+++ b/include/config/LocationConfig.hpp
@@ -8,19 +8,16 @@
 namespace config {
 
 	struct LocationConfig {
-			std::string path;									 // location name split into tokens
-			std::vector<std::string> pathAsTokens;				 // location name split into tokens
-			std::string root;									 // root split into tokens
-			std::string precalculatedAbsolutePath;				 // absolute path to this location's root, pre-calculated after parsing
-			std::vector<std::string> rootAsTokens;				 // root split into tokens
-			std::string redirectUri;							 // return route (references other locations)
-			std::vector<std::string> redirectUriAsTokens;		 // return route split into tokens
-			std::set<http::Method> allowedMethods;				 // allowed HTTP methods
-			std::string uploadSubdirectory;						 // subdirectory for uploads
-			std::vector<std::string> uploadSubdirectoryAsTokens; //
-			bool autoindex;										 //
-			std::vector<std::string> indexFile;					 // files to load when GETting a directory
-			std::vector<LocationConfig> locations;				 // registered locations
+			std::string path;					   // location name split into tokens
+			std::string root;					   // root split into tokens
+			std::string precalculatedAbsolutePath; // absolute path to this location's root, pre-calculated after parsing
+			std::string redirectUri;			   // return route (references other locations)
+			http::StatusCode returnClass;		   // type of redirect
+			std::set<http::Method> allowedMethods; // allowed HTTP methods
+			std::string uploadSubdirectory;		   // subdirectory for uploads
+			bool autoindex;						   //
+			std::vector<std::string> indexFile;	   // files to load when GETting a directory
+			std::vector<LocationConfig> locations; // registered locations
 
 			LocationConfig();
 			LocationConfig(const LocationConfig& other);

--- a/include/config/ServerConfig.hpp
+++ b/include/config/ServerConfig.hpp
@@ -18,7 +18,6 @@ namespace config {
 			unsigned long maxHeaderValueCount;
 			unsigned long maxHeaderNameLength;
 			std::string dataDirectory;
-			std::vector<std::string> dataDirectoryAsTokens;
 			std::vector<std::string> serverNames;
 			LocationConfig location;
 

--- a/include/core/RequestProcessor.hpp
+++ b/include/core/RequestProcessor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "config/ServerConfig.hpp"
 #include "core/CGIProcessor.hpp"
 #include "http/http.hpp"
 #include "io/Dispatcher.hpp"
@@ -18,7 +19,7 @@ namespace core {
 
 	class RequestProcessor : shared::mixin::NonCopyable {
 		public:
-			explicit RequestProcessor(io::Dispatcher& dispatcher);
+			explicit RequestProcessor(const config::ServerConfig& serverConfig, io::Dispatcher& dispatcher);
 			~RequestProcessor();
 
 			bool processRequest(const http::Request& request);
@@ -32,6 +33,7 @@ namespace core {
 			void generateErrorResponse(http::StatusCode statusCode);
 
 		private:
+			const config::ServerConfig m_serverConfig;
 			CGIProcessor m_cgiProcessor;
 			http::Response* m_response;
 			HandlerMap m_handlers;

--- a/include/core/RequestProcessor.hpp
+++ b/include/core/RequestProcessor.hpp
@@ -5,6 +5,7 @@
 #include "http/http.hpp"
 #include "io/Dispatcher.hpp"
 #include "shared/NonCopyable.hpp"
+#include "shared/StringView.hpp"
 
 #include <map>
 
@@ -16,6 +17,19 @@ namespace http {
 namespace core {
 
 	class ARequestHandler;
+
+	class RouteResult : shared::mixin::NonCopyable {
+		public:
+			RouteResult(const config::LocationConfig& location, const std::string& filePath)
+				: location(location)
+				, filePath(filePath) {}
+
+			~RouteResult() {}
+
+		public:
+			const config::LocationConfig& location;
+			const std::string filePath;
+	};
 
 	class RequestProcessor : shared::mixin::NonCopyable {
 		public:
@@ -31,12 +45,18 @@ namespace core {
 			typedef std::map<http::Method, ARequestHandler*> HandlerMap;
 
 			void generateErrorResponse(http::StatusCode statusCode);
+			void generateRedirectResponse();
+
+			RouteResult* route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth = 0);
 
 		private:
 			const config::ServerConfig m_serverConfig;
 			CGIProcessor m_cgiProcessor;
 			http::Response* m_response;
+			RouteResult* m_route;
 			HandlerMap m_handlers;
+
+			static const std::size_t MAX_ROUTE_DEPTH = 8;
 	};
 
 } /* namespace core */

--- a/include/core/RequestProcessor.hpp
+++ b/include/core/RequestProcessor.hpp
@@ -41,8 +41,6 @@ namespace core {
 			http::Response* m_response;
 			HandlerMap m_handlers;
 			Router m_router;
-
-			static const std::size_t MAX_ROUTE_DEPTH = 8;
 	};
 
 } /* namespace core */

--- a/include/core/RequestProcessor.hpp
+++ b/include/core/RequestProcessor.hpp
@@ -2,6 +2,7 @@
 
 #include "config/ServerConfig.hpp"
 #include "core/CGIProcessor.hpp"
+#include "core/Router.hpp"
 #include "http/http.hpp"
 #include "io/Dispatcher.hpp"
 #include "shared/NonCopyable.hpp"
@@ -17,19 +18,6 @@ namespace http {
 namespace core {
 
 	class ARequestHandler;
-
-	class RouteResult : shared::mixin::NonCopyable {
-		public:
-			RouteResult(const config::LocationConfig& location, const std::string& filePath)
-				: location(location)
-				, filePath(filePath) {}
-
-			~RouteResult() {}
-
-		public:
-			const config::LocationConfig& location;
-			const std::string filePath;
-	};
 
 	class RequestProcessor : shared::mixin::NonCopyable {
 		public:
@@ -47,14 +35,12 @@ namespace core {
 			void generateErrorResponse(http::StatusCode statusCode);
 			void generateRedirectResponse();
 
-			RouteResult* route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth = 0);
-
 		private:
-			const config::ServerConfig m_serverConfig;
+			const config::ServerConfig& m_serverConfig;
 			CGIProcessor m_cgiProcessor;
 			http::Response* m_response;
-			RouteResult* m_route;
 			HandlerMap m_handlers;
+			Router m_router;
 
 			static const std::size_t MAX_ROUTE_DEPTH = 8;
 	};

--- a/include/core/Router.hpp
+++ b/include/core/Router.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "config/LocationConfig.hpp"
+#include "shared/NonCopyable.hpp"
+#include "shared/StringView.hpp"
+
+#include <string>
+
+namespace core {
+
+	class Router : public shared::mixin::NonCopyable {
+		private:
+			struct Route : shared::mixin::NonCopyable {
+				public:
+					Route();
+					~Route();
+
+					bool empty() const;
+					void reset();
+
+				public:
+					const config::LocationConfig* location;
+					std::string filePath;
+			};
+
+		public:
+			Router();
+			~Router();
+
+		public:
+			void route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth = 0);
+			void reset();
+
+			bool needsRoute() const;
+			bool foundRedirect() const;
+			const Route& getResult() const;
+			std::string generateRedirectUri() const;
+			http::StatusCode getReturnClass() const;
+
+		private:
+			Route m_routeResult;
+			static const std::size_t MAX_ROUTE_DEPTH = 8;
+	};
+
+} /* namespace core */

--- a/include/core/VirtualServer.hpp
+++ b/include/core/VirtualServer.hpp
@@ -22,6 +22,7 @@ namespace core {
 			const io::Socket& getListenSocket() const;
 			std::string getVirtualServerInfo() const;
 			const std::vector<Connection*>& getActiveConnections() const;
+			const config::ServerConfig& getServerConfig() const;
 
 		private:
 			static const time_t CONNECTION_TIMEOUT;

--- a/include/io/IEventHandler.hpp
+++ b/include/io/IEventHandler.hpp
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 
-#include <shared/NonCopyable.hpp>
+#include "shared/NonCopyable.hpp"
 
 namespace io {
 

--- a/src/config/LocationConfig.cpp
+++ b/src/config/LocationConfig.cpp
@@ -8,14 +8,12 @@ namespace config {
 
 	LocationConfig::LocationConfig()
 		: path()
-		, pathAsTokens()
 		, root()
 		, precalculatedAbsolutePath()
 		, redirectUri()
-		, redirectUriAsTokens()
+		, returnClass(http::MOVED_PERMANENTLY)
 		, allowedMethods()
 		, uploadSubdirectory()
-		, uploadSubdirectoryAsTokens()
 		, autoindex(false)
 		, indexFile()
 		, locations() {
@@ -26,14 +24,12 @@ namespace config {
 
 	LocationConfig::LocationConfig(const LocationConfig& other)
 		: path(other.path)
-		, pathAsTokens(other.pathAsTokens)
 		, root(other.root)
 		, precalculatedAbsolutePath(other.precalculatedAbsolutePath)
 		, redirectUri(other.redirectUri)
-		, redirectUriAsTokens(other.redirectUriAsTokens)
+		, returnClass(other.returnClass)
 		, allowedMethods(other.allowedMethods)
 		, uploadSubdirectory(other.uploadSubdirectory)
-		, uploadSubdirectoryAsTokens(other.uploadSubdirectoryAsTokens)
 		, autoindex(other.autoindex)
 		, indexFile(other.indexFile)
 		, locations(other.locations) {
@@ -42,14 +38,12 @@ namespace config {
 	LocationConfig& LocationConfig::operator=(const LocationConfig& other) {
 		if (this != &other) {
 			path = other.path;
-			pathAsTokens = other.pathAsTokens;
 			root = other.root;
 			precalculatedAbsolutePath = other.precalculatedAbsolutePath;
 			redirectUri = other.redirectUri;
-			redirectUriAsTokens = other.redirectUriAsTokens;
+			returnClass = other.returnClass;
 			allowedMethods = other.allowedMethods;
 			uploadSubdirectory = other.uploadSubdirectory;
-			uploadSubdirectoryAsTokens = other.uploadSubdirectoryAsTokens;
 			autoindex = other.autoindex;
 			indexFile = other.indexFile;
 			locations = other.locations;
@@ -80,23 +74,7 @@ namespace config {
 	void LocationConfig::printIndented(int indentLevel) const {
 		std::string indent(indentLevel, ' ');
 
-		std::cout << indent << "LocationConfig: ";
-		if (!pathAsTokens.empty()) {
-			for (std::vector<std::string>::const_iterator it = pathAsTokens.begin(); it != pathAsTokens.end(); ++it) {
-				std::cout << "/" << *it;
-			}
-		} else {
-			std::cout << "/";
-		}
-		std::cout << std::endl;
-
-		if (!rootAsTokens.empty()) {
-			std::cout << indent << "  Root: ";
-			for (std::vector<std::string>::const_iterator it = rootAsTokens.begin(); it != rootAsTokens.end(); ++it) {
-				std::cout << *it << " ";
-			}
-			std::cout << std::endl;
-		}
+		std::cout << indent << "LocationConfig: " << path << std::endl;
 
 		if (!root.empty()) {
 			std::cout << indent << "  Root (string): " << root << std::endl;

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -315,6 +315,8 @@ namespace config {
 
 		ServerConfig thisServer;
 
+		thisServer.location.path = "/";
+
 		while (m_readPos < m_data.size()) {
 			skipWhitespace();
 			if (m_readPos < m_data.size() && m_data[m_readPos] == '{') {

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -372,7 +372,6 @@ namespace config {
 		LocationConfig thisLocation;
 
 		thisLocation.path = path;
-		thisLocation.pathAsTokens = shared::string::split(path, '/');
 		while (m_readPos <= m_data.size()) {
 			skipWhitespace();
 			if (m_readPos < m_data.size() && m_data[m_readPos] == '{') {
@@ -424,9 +423,7 @@ namespace config {
 			case D_MAX_HEADER_VALUE_SIZE:
 				return parseIntegerValue("max_header_value_length", value, server.maxHeaderValueLength);
 			case D_DATA_DIR:
-				parsePathValue("data_dir", value, server.dataDirectory);
-				server.dataDirectoryAsTokens = shared::string::split(value, '/'); // strip this of whitespace if that doesn't happen yet
-				return;
+				return parsePathValue("data_dir", value, server.dataDirectory);
 			default:
 				return (this->*(tokenParsers[type]))(value, server);
 		}
@@ -444,13 +441,9 @@ namespace config {
 
 		switch (type) {
 			case D_ROOT:
-				parsePathValue(key, value, location.root);
-				location.rootAsTokens = shared::string::split(location.root, '/');
-				return;
+				return parsePathValue(key, value, location.root);
 			case D_UPLOAD_DIR:
-				parsePathValue(key, value, location.uploadSubdirectory);
-				location.uploadSubdirectoryAsTokens = shared::string::split(location.uploadSubdirectory, '/');
-				return;
+				return parsePathValue(key, value, location.uploadSubdirectory);
 			default:
 				return (this->*(tokenParsers[type]))(value, location);
 		}
@@ -558,7 +551,6 @@ namespace config {
 		if (!isValidPath(value)) {
 			throw parse_exception(m_lineIndex, "Invalid path for return: " + value);
 		}
-		location.redirectUriAsTokens = shared::string::split(value, '/'); // ensure this won't throw
 		location.redirectUri = value;
 	}
 

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -15,7 +15,6 @@ namespace config {
 		, maxHeaderValueCount(64)		 // 64 values
 		, maxHeaderNameLength(256)		 // 256B
 		, dataDirectory("")
-		, dataDirectoryAsTokens()
 		, serverNames()
 		, location() {}
 
@@ -30,7 +29,6 @@ namespace config {
 		, maxHeaderValueCount(other.maxHeaderValueCount)
 		, maxHeaderNameLength(other.maxHeaderNameLength)
 		, dataDirectory(other.dataDirectory)
-		, dataDirectoryAsTokens(other.dataDirectoryAsTokens)
 		, serverNames(other.serverNames)
 		, location(other.location) {}
 
@@ -46,7 +44,6 @@ namespace config {
 		maxHeaderValueCount = rhs.maxHeaderValueCount;
 		maxHeaderValueLength = rhs.maxHeaderValueLength;
 		dataDirectory = rhs.dataDirectory;
-		dataDirectoryAsTokens = rhs.dataDirectoryAsTokens;
 		serverNames = rhs.serverNames;
 		location = rhs.location;
 		return *this;

--- a/src/core/ConnectionEventHandler.cpp
+++ b/src/core/ConnectionEventHandler.cpp
@@ -13,7 +13,7 @@ namespace core {
 		: m_vServer(vServer)
 		, m_connection(conn)
 		, m_requestParser()
-		, m_requestProcessor(dispatcher)
+		, m_requestProcessor(vServer.getServerConfig(), dispatcher)
 		, m_totalBytesSent(0)
 		, m_requests()
 		, m_responses() {

--- a/src/core/RequestProcessor.cpp
+++ b/src/core/RequestProcessor.cpp
@@ -1,5 +1,7 @@
 #include "core/RequestProcessor.hpp"
 
+#include "config/LocationConfig.hpp"
+#include "config/ServerConfig.hpp"
 #include "core/ARequestHandler.hpp"
 #include "core/DeleteRequestHandler.hpp"
 #include "core/GetRequestHandler.hpp"
@@ -8,6 +10,7 @@
 #include "http/Response.hpp"
 #include "http/http.hpp"
 #include "shared/Logger.hpp"
+#include "shared/StringView.hpp"
 #include "shared/stringUtils.hpp"
 
 namespace core {
@@ -15,7 +18,9 @@ namespace core {
 	RequestProcessor::RequestProcessor(const config::ServerConfig& serverConfig, io::Dispatcher& dispatcher)
 		: m_serverConfig(serverConfig)
 		, m_cgiProcessor(dispatcher)
-		, m_response(NULL) {
+		, m_response(NULL)
+		, m_route(NULL)
+		, m_handlers() {
 		m_handlers[http::GET] = new GetRequestHandler();
 		m_handlers[http::POST] = new PostRequestHandler();
 		m_handlers[http::DELETE] = new DeleteRequestHandler();
@@ -26,24 +31,30 @@ namespace core {
 			delete it->second;
 		}
 		delete m_response;
+		delete m_route;
 	}
 
 	// todo maybe have a isComplete function. the return value could be confusing
 	bool RequestProcessor::processRequest(const http::Request& request) {
 		if (!m_response) {
 			m_response = new http::Response();
-			// route here? if we can validate first
-		}
-
-		if (request.isValid() == false) { // yeah this is kinda weird...
-			generateErrorResponse(request.getStatusCode());
-			return false;
+			if (request.isValid() == false) { // yeah this is kinda weird...
+				generateErrorResponse(request.getStatusCode());
+				return false;
+			}
 		}
 
 		try {
 			http::Request::Type requestType = request.getType();
 
 			if (requestType == http::Request::FETCH) {
+				if (m_route == NULL) {
+					m_route = RequestProcessor::route(shared::string::StringView(request.getUri().getPath().c_str()), m_serverConfig.location);
+				}
+				if (m_route->location.hasRedirect()) {
+					generateRedirectResponse();
+					return false;
+				}
 				ARequestHandler* handler = m_handlers[request.getMethod()];
 				if (handler->handle(request, *m_response)) {
 					return true;
@@ -71,12 +82,16 @@ namespace core {
 	http::Response* RequestProcessor::releaseResponse() {
 		http::Response* released = m_response;
 		m_response = NULL;
+		delete m_route;
+		m_route = NULL;
 		return released;
 	}
 
 	void RequestProcessor::reset() {
 		delete m_response;
 		m_response = NULL;
+		delete m_route;
+		m_route = NULL;
 
 		for (HandlerMap::iterator it = m_handlers.begin(); it != m_handlers.end(); ++it) {
 			it->second->reset();
@@ -86,7 +101,38 @@ namespace core {
 	}
 
 	void RequestProcessor::generateErrorResponse(http::StatusCode) {
-		m_response->appendBody("tmp error response\n"); // tmp
+		m_response->appendBody("tmp error response\n"); // todo:
 	}
+
+	void RequestProcessor::generateRedirectResponse() {
+		m_response->appendBody("tmp redirect response\n"); // todo:
+		m_response->setStatusCode(http::MOVED_PERMANENTLY);
+	}
+
+	RouteResult* RequestProcessor::route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth) {
+		std::cout << "routing to '" << uriPath << "' in location '" << currentLocation.path << "'" << std::endl;
+		if (currentLocation.hasRedirect()) {
+			return new RouteResult(currentLocation, uriPath.toString());
+		}
+		if (depth > MAX_ROUTE_DEPTH) {
+			throw http::HttpException(http::LOOP_DETECTED, "Depth exceeded MAX_ROUTE_DEPTH");
+		}
+		for (std::vector<config::LocationConfig>::const_iterator location = currentLocation.locations.begin(); location != currentLocation.locations.end(); ++location) {
+			shared::string::StringView pathView(location->path.c_str());
+			if (!pathView.empty() && uriPath.find(pathView, 0) == 0) {
+				return route(uriPath.substr(pathView.size()), *location, depth + 1);
+			}
+		}
+		return new RouteResult(currentLocation, uriPath.toString());
+	}
+
+	// returns pair of location & file name (including subdirectories)
+	// e.g. get /foo/bar/baz.txt would return the foo location & "/bar/baz.txt" if /foo doesn't have a /bar sublocation
+	// what happens if we hit a redirection?
+	// on redirection: respond with RETURN_CODE as status code
+	// and in a Location header, put the new URI
+	// most likely this will be <redirect_uri>/<rest>/<of>/<path>/<to>.<match>
+	// in any case, if the router hits a location with "return" in it, it immediately returns that location + the remaining path as string
+	// then in RequestProcessor::process(), we simply check if the location has a return; if it does, send redirect response with location.returnPath + routerReturnedPair.second.
 
 } // namespace core

--- a/src/core/RequestProcessor.cpp
+++ b/src/core/RequestProcessor.cpp
@@ -12,8 +12,9 @@
 
 namespace core {
 
-	RequestProcessor::RequestProcessor(io::Dispatcher& dispatcher)
-		: m_cgiProcessor(dispatcher)
+	RequestProcessor::RequestProcessor(const config::ServerConfig& serverConfig, io::Dispatcher& dispatcher)
+		: m_serverConfig(serverConfig)
+		, m_cgiProcessor(dispatcher)
 		, m_response(NULL) {
 		m_handlers[http::GET] = new GetRequestHandler();
 		m_handlers[http::POST] = new PostRequestHandler();
@@ -31,6 +32,7 @@ namespace core {
 	bool RequestProcessor::processRequest(const http::Request& request) {
 		if (!m_response) {
 			m_response = new http::Response();
+			// route here? if we can validate first
 		}
 
 		if (request.isValid() == false) { // yeah this is kinda weird...

--- a/src/core/RequestProcessor.cpp
+++ b/src/core/RequestProcessor.cpp
@@ -19,8 +19,8 @@ namespace core {
 		: m_serverConfig(serverConfig)
 		, m_cgiProcessor(dispatcher)
 		, m_response(NULL)
-		, m_route(NULL)
-		, m_handlers() {
+		, m_handlers()
+		, m_router() {
 		m_handlers[http::GET] = new GetRequestHandler();
 		m_handlers[http::POST] = new PostRequestHandler();
 		m_handlers[http::DELETE] = new DeleteRequestHandler();
@@ -31,7 +31,6 @@ namespace core {
 			delete it->second;
 		}
 		delete m_response;
-		delete m_route;
 	}
 
 	// todo maybe have a isComplete function. the return value could be confusing
@@ -48,12 +47,12 @@ namespace core {
 			http::Request::Type requestType = request.getType();
 
 			if (requestType == http::Request::FETCH) {
-				if (m_route == NULL) {
-					m_route = RequestProcessor::route(shared::string::StringView(request.getUri().getPath().c_str()), m_serverConfig.location);
-				}
-				if (m_route->location.hasRedirect()) {
-					generateRedirectResponse();
-					return false;
+				if (m_router.needsRoute()) {
+					m_router.route(shared::string::StringView(request.getUri().getPath().c_str()), m_serverConfig.location);
+					if (m_router.foundRedirect()) {
+						generateRedirectResponse();
+						return false;
+					}
 				}
 				ARequestHandler* handler = m_handlers[request.getMethod()];
 				if (handler->handle(request, *m_response)) {
@@ -82,16 +81,13 @@ namespace core {
 	http::Response* RequestProcessor::releaseResponse() {
 		http::Response* released = m_response;
 		m_response = NULL;
-		delete m_route;
-		m_route = NULL;
 		return released;
 	}
 
 	void RequestProcessor::reset() {
 		delete m_response;
 		m_response = NULL;
-		delete m_route;
-		m_route = NULL;
+		m_router.reset();
 
 		for (HandlerMap::iterator it = m_handlers.begin(); it != m_handlers.end(); ++it) {
 			it->second->reset();
@@ -104,36 +100,11 @@ namespace core {
 		m_response->appendBody("tmp error response\n"); // todo:
 	}
 
+	// todo: add Location header with new uri
 	void RequestProcessor::generateRedirectResponse() {
 		m_response->appendBody("tmp redirect response\n"); // todo:
-		m_response->appendBody(m_route->location.redirectUri + m_route->filePath + "\n");
-		m_response->setStatusCode(m_route->location.returnClass);
+		m_response->appendBody(m_router.generateRedirectUri() + "\n");
+		m_response->setStatusCode(m_router.getReturnClass());
 	}
-
-	RouteResult* RequestProcessor::route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth) {
-		std::cout << "routing to '" << uriPath << "' in location '" << currentLocation.path << "'" << std::endl;
-		if (currentLocation.hasRedirect()) {
-			return new RouteResult(currentLocation, uriPath.toString());
-		}
-		if (depth > MAX_ROUTE_DEPTH) {
-			throw http::HttpException(http::LOOP_DETECTED, "Depth exceeded MAX_ROUTE_DEPTH");
-		}
-		for (std::vector<config::LocationConfig>::const_iterator location = currentLocation.locations.begin(); location != currentLocation.locations.end(); ++location) {
-			shared::string::StringView pathView(location->path.c_str());
-			if (!pathView.empty() && uriPath.find(pathView, 0) == 0) {
-				return route(uriPath.substr(pathView.size()), *location, depth + 1);
-			}
-		}
-		return new RouteResult(currentLocation, uriPath.toString());
-	}
-
-	// returns pair of location & file name (including subdirectories)
-	// e.g. get /foo/bar/baz.txt would return the foo location & "/bar/baz.txt" if /foo doesn't have a /bar sublocation
-	// what happens if we hit a redirection?
-	// on redirection: respond with RETURN_CODE as status code
-	// and in a Location header, put the new URI
-	// most likely this will be <redirect_uri>/<rest>/<of>/<path>/<to>.<match>
-	// in any case, if the router hits a location with "return" in it, it immediately returns that location + the remaining path as string
-	// then in RequestProcessor::process(), we simply check if the location has a return; if it does, send redirect response with location.returnPath + routerReturnedPair.second.
 
 } // namespace core

--- a/src/core/RequestProcessor.cpp
+++ b/src/core/RequestProcessor.cpp
@@ -106,7 +106,8 @@ namespace core {
 
 	void RequestProcessor::generateRedirectResponse() {
 		m_response->appendBody("tmp redirect response\n"); // todo:
-		m_response->setStatusCode(http::MOVED_PERMANENTLY);
+		m_response->appendBody(m_route->location.redirectUri + m_route->filePath + "\n");
+		m_response->setStatusCode(m_route->location.returnClass);
 	}
 
 	RouteResult* RequestProcessor::route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth) {

--- a/src/core/Router.cpp
+++ b/src/core/Router.cpp
@@ -1,0 +1,56 @@
+#include "core/Router.hpp"
+
+namespace core {
+
+	Router::Router()
+		: m_routeResult() {}
+
+	Router::~Router() {}
+
+	void Router::route(const shared::string::StringView& uriPath, const config::LocationConfig& currentLocation, std::size_t depth) {
+		if (currentLocation.hasRedirect()) {
+			m_routeResult.filePath = uriPath.toString();
+			m_routeResult.location = &currentLocation;
+			return;
+		}
+		if (depth > MAX_ROUTE_DEPTH) {
+			throw http::HttpException(http::LOOP_DETECTED, "Depth exceeded MAX_ROUTE_DEPTH");
+		}
+		for (std::vector<config::LocationConfig>::const_iterator location = currentLocation.locations.begin(); location != currentLocation.locations.end(); ++location) {
+			shared::string::StringView pathView(location->path.c_str());
+			if (!pathView.empty() && uriPath.find(pathView, 0) == 0) {
+				return route(uriPath.substr(pathView.size()), *location, depth + 1);
+			}
+		}
+		m_routeResult.location = &currentLocation;
+		m_routeResult.filePath = uriPath.toString();
+	}
+
+	bool Router::needsRoute() const { return m_routeResult.empty(); }
+
+	bool Router::foundRedirect() const { return m_routeResult.location->hasRedirect(); }
+
+	void Router::reset() { m_routeResult.reset(); }
+
+	std::string Router::generateRedirectUri() const { return m_routeResult.location->redirectUri + m_routeResult.filePath; }
+
+	http::StatusCode Router::getReturnClass() const { return m_routeResult.location->returnClass; }
+
+	// ------------------------  Route class implementation  ---------
+
+	Router::Route::Route()
+		: location(NULL)
+		, filePath("") {}
+
+	Router::Route::~Route() {}
+
+	bool Router::Route::empty() const { return location == NULL; }
+
+	void Router::Route::reset() {
+		location = NULL;
+		filePath.clear();
+	}
+
+	const Router::Route& Router::getResult() const { return m_routeResult; }
+
+} /* namespace core */

--- a/src/core/VirtualServer.cpp
+++ b/src/core/VirtualServer.cpp
@@ -1,8 +1,11 @@
 #include "core/VirtualServer.hpp"
 
-#include "ctime"
+#include <unistd.h>
+
 #include "shared/Logger.hpp"
-#include "sstream"
+
+#include <ctime>
+#include <sstream>
 
 namespace core {
 

--- a/src/core/VirtualServer.cpp
+++ b/src/core/VirtualServer.cpp
@@ -104,4 +104,6 @@ namespace core {
 
 	const std::vector<Connection*>& VirtualServer::getActiveConnections() const { return m_connections; }
 
+	const config::ServerConfig& VirtualServer::getServerConfig() const { return m_config; }
+
 } /* namespace core */


### PR DESCRIPTION
### Description

This PR implements a simplified version of the previous routing logic, inside of RequestProcessor. Redirections are no longer handled by us, instead a generateRedirectResponse() will take care of the proper response.
It also removes tokenised paths from the ServerConfig and LocationConfig structs.

Does not yet validate whether a file or resource exists.