### PR TITLE
fix/cgi/pipe

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
         "Gruntfuggly.todo-tree",
         "wayou.vscode-todo-highlight",
         "augustocdias.tasks-shell-input",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "ms-python.python"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh",

--- a/include/core/CGIProcessor.hpp
+++ b/include/core/CGIProcessor.hpp
@@ -46,9 +46,12 @@ namespace core {
 			void executeCGIScript(const http::Request& request);
 			const std::string& getInterpreter();
 
+			bool monitor();
 			bool waitCGIScript();
 
 			bool isIOComplete() const;
+			bool isIOReadComplete() const;
+			bool isIOWriteComplete() const;
 			bool hasIOError() const;
 			void cleanup();
 


### PR DESCRIPTION
This PR fixes a issue with python cgi.test().
The script waited until the read pipe is closed so it stops reading from stdin.
Now we just close the appropriate pipe when in/out handler is complete.