### PR TITLE
fix(directoryListing): '..' directory handling

### DIFF
--- a/include/config/LocationConfig.hpp
+++ b/include/config/LocationConfig.hpp
@@ -8,14 +8,15 @@
 namespace config {
 
 	struct LocationConfig {
-			std::string path;					   // location name split into tokens
-			std::string root;					   // root split into tokens
+			std::string path;					   // location name
+			std::string root;					   // root
 			std::string precalculatedAbsolutePath; // absolute path to this location's root, pre-calculated after parsing
 			std::string redirectUri;			   // return route (references other locations)
 			http::StatusCode returnClass;		   // type of redirect
 			std::set<http::Method> allowedMethods; // allowed HTTP methods
 			std::string uploadSubdirectory;		   // subdirectory for uploads
 			bool autoindex;						   //
+			bool isServerRoot;					   //
 			std::vector<std::string> indexFile;	   // files to load when GETting a directory
 			std::vector<LocationConfig> locations; // registered locations
 

--- a/src/config/LocationConfig.cpp
+++ b/src/config/LocationConfig.cpp
@@ -15,6 +15,7 @@ namespace config {
 		, allowedMethods()
 		, uploadSubdirectory()
 		, autoindex(false)
+		, isServerRoot(false)
 		, indexFile()
 		, locations() {
 		allowedMethods.insert(http::GET);
@@ -31,6 +32,7 @@ namespace config {
 		, allowedMethods(other.allowedMethods)
 		, uploadSubdirectory(other.uploadSubdirectory)
 		, autoindex(other.autoindex)
+		, isServerRoot(other.isServerRoot)
 		, indexFile(other.indexFile)
 		, locations(other.locations) {
 	}
@@ -45,6 +47,7 @@ namespace config {
 			allowedMethods = other.allowedMethods;
 			uploadSubdirectory = other.uploadSubdirectory;
 			autoindex = other.autoindex;
+			isServerRoot = other.isServerRoot;
 			indexFile = other.indexFile;
 			locations = other.locations;
 		}
@@ -101,6 +104,7 @@ namespace config {
 		}
 
 		std::cout << indent << "  Autoindex: " << (autoindex ? "on" : "off") << std::endl;
+		std::cout << indent << "  isServerRoot: " << (isServerRoot ? "true" : "false") << std::endl;
 
 		if (!indexFile.empty()) {
 			std::cout << indent << "  Index Files: ";

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -315,6 +315,7 @@ namespace config {
 		ServerConfig thisServer;
 
 		thisServer.location.path = "/";
+		thisServer.location.isServerRoot = true;
 
 		while (m_readPos < m_data.size()) {
 			skipWhitespace();

--- a/src/core/GetRequestHandler.cpp
+++ b/src/core/GetRequestHandler.cpp
@@ -75,7 +75,7 @@ namespace core {
 			if (fileName == ".") {
 				continue;
 			}
-			if (fileName == ".." && (m_route.remainingPath == "/" || m_route.remainingPath == "")) {
+			if (fileName == ".." && m_route.location->isServerRoot == true && m_route.remainingPath == "/") {
 				continue;
 			}
 			std::string baseUrl = request.getUri().getAuthority();
@@ -138,7 +138,10 @@ namespace core {
 
 	bool GetRequestHandler::readFile(http::Response& response) {
 		m_fileStream.read(m_buffer.data(), BUFFER_SIZE);
-		if (m_fileStream.fail()) {
+		std::cout << "read returned " << errno << std::endl;
+		std::cout << "read badbit " << m_fileStream.bad() << std::endl;
+		std::cout << "read failbit " << m_fileStream.eof() << std::endl;
+		if (m_fileStream.bad()) {
 			m_fileStream.close();
 			throw http::HttpException(http::INTERNAL_SERVER_ERROR, "GET: Failure during read() occurred");
 		}

--- a/src/core/GetRequestHandler.cpp
+++ b/src/core/GetRequestHandler.cpp
@@ -138,9 +138,6 @@ namespace core {
 
 	bool GetRequestHandler::readFile(http::Response& response) {
 		m_fileStream.read(m_buffer.data(), BUFFER_SIZE);
-		std::cout << "read returned " << errno << std::endl;
-		std::cout << "read badbit " << m_fileStream.bad() << std::endl;
-		std::cout << "read failbit " << m_fileStream.eof() << std::endl;
 		if (m_fileStream.bad()) {
 			m_fileStream.close();
 			throw http::HttpException(http::INTERNAL_SERVER_ERROR, "GET: Failure during read() occurred");

--- a/src/core/PostRequestHandler.cpp
+++ b/src/core/PostRequestHandler.cpp
@@ -91,7 +91,7 @@ namespace core {
 		std::size_t bytesToWrite = std::min(requestBody.size() - m_bytesWritten, CHUNK_SIZE);
 
 		m_fileStream.write(requestBody.data() + m_bytesWritten, bytesToWrite);
-		if (m_fileStream.fail()) {
+		if (m_fileStream.bad()) {
 			m_fileStream.close();
 			throw http::HttpException(http::INTERNAL_SERVER_ERROR, "POST: Failure during write() occurred");
 		}


### PR DESCRIPTION
This PR includes a small fix to the directoryListing's handling of '../'. It now shows up everywhere except for the server's root dir (../) to keep users from escaping.

Closes #89 