### PR TITLE
fix: check for underflow

### DIFF
--- a/include/shared/stringUtils.hpp
+++ b/include/shared/stringUtils.hpp
@@ -10,7 +10,13 @@ namespace shared {
 		};
 
 		template <typename T>
-		T toNum(const std::string& str, std::ios_base& (*baseManipulator)(std::ios_base&) = NULL) {
+		T toUnsignedNum(const std::string& str, std::ios_base& (*baseManipulator)(std::ios_base&) = NULL) {
+			for (std::size_t i = 0; str[i]; ++i) {
+				if (std::isdigit(str[i]) == false) {
+					throw std::runtime_error("invalid character found during conversion: " + std::string(1, str[i]));
+				}
+			}
+
 			T result;
 			std::istringstream stream(str);
 
@@ -19,8 +25,9 @@ namespace shared {
 			}
 
 			stream >> result;
-			if (stream.fail() || !stream.eof())
+			if (stream.fail() || !stream.eof()) {
 				throw std::runtime_error("cant convert to number");
+			}
 			return result;
 		}
 

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -498,7 +498,7 @@ namespace config {
 			if (segment.size() > 3) {
 				throw parse_exception(m_lineIndex, "Invalid IP address format: segment too long in \"" + host + "\"");
 			}
-			int octet = shared::string::toNum<int>(segment);
+			unsigned int octet = shared::string::toUnsignedNum<int>(segment);
 			if (octet < 0 || octet > 255) {
 				throw parse_exception(m_lineIndex, "IP segment out of range in \"" + host + "\"");
 			}

--- a/src/http/AMessageParser.cpp
+++ b/src/http/AMessageParser.cpp
@@ -228,7 +228,7 @@ namespace http {
 			}
 
 			try {
-				m_contentLength = shared::string::toNum<std::size_t>(values.front());
+				m_contentLength = shared::string::toUnsignedNum<std::size_t>(values.front());
 			} catch (const std::bad_alloc&) {
 				throw;
 			} catch (const std::exception& e) {
@@ -304,7 +304,7 @@ namespace http {
 		shared::string::StringView sizeView = line.substr(0, semicolonPos);
 
 		try {
-			m_contentLength = shared::string::toNum<std::size_t>(sizeView.toString(), std::hex);
+			m_contentLength = shared::string::toUnsignedNum<std::size_t>(sizeView.toString(), std::hex);
 		} catch (const std::bad_alloc&) {
 			throw;
 		} catch (std::exception& e) {

--- a/src/http/ResponseParser.cpp
+++ b/src/http/ResponseParser.cpp
@@ -51,7 +51,7 @@ namespace http {
 
 		shared::string::StringView codeView = line.substr(firstSpace + 1, secondSpace - firstSpace - 1);
 		try {
-			std::size_t code = shared::string::toNum<std::size_t>(codeView.toString());
+			std::size_t code = shared::string::toUnsignedNum<std::size_t>(codeView.toString());
 			m_response->setStatusCode(numToStatusCode(code));
 		} catch (const std::bad_alloc&) {
 			throw;
@@ -85,7 +85,7 @@ namespace http {
 			}
 
 			try {
-				StatusCode code = numToStatusCode(shared::string::toNum<std::size_t>(codeStr));
+				StatusCode code = numToStatusCode(shared::string::toUnsignedNum<std::size_t>(codeStr));
 				m_response->setStatusCode(code);
 
 				if (!reasonPhrase.empty()) {


### PR DESCRIPTION
Somehow istringview doesnt check for underflow.
So now I just changed toNum to toUnsignedNum and check for non digit chars so we dont have the problem anymore.

Closes #106 