### PR TITLE
feat(getHandler): set Content-Type response header

### DIFF
--- a/include/core/GetRequestHandler.hpp
+++ b/include/core/GetRequestHandler.hpp
@@ -26,6 +26,7 @@ namespace core {
 			bool readFile(http::Response& response);
 			void generateAutoindexResponse(const http::Request& request, http::Response& response);
 			std::string generateDirectoryListing(const http::Request& request, const std::string& filePath);
+			const std::string& getMimeType() const;
 
 		private:
 			static const std::streamsize BUFFER_SIZE = 16384; // 16 KB

--- a/src/core/GetRequestHandler.cpp
+++ b/src/core/GetRequestHandler.cpp
@@ -43,6 +43,7 @@ namespace core {
 	}
 
 	const std::string& GetRequestHandler::getMimeType() const {
+		static std::string octetStreamType = "application/octet-stream";
 		static std::map<std::string, std::string> contentTypes;
 
 		if (contentTypes.empty()) {
@@ -95,14 +96,16 @@ namespace core {
 			contentTypes[".7z"] = "application/x-7z-compressed";
 		}
 
-		std::string fileExtension = m_filePath.substr(m_filePath.rfind('.'));
+		std::size_t lastDot = m_filePath.rfind('.');
+		if (lastDot == std::string::npos) {
+			return octetStreamType;
+		}
+		std::string fileExtension = m_filePath.substr(lastDot);
 		if (fileExtension.find('/') != std::string::npos) {
-			static std::string htmlType = "text/html";
-			return htmlType;
+			return octetStreamType;
 		}
 		std::map<std::string, std::string>::iterator type = contentTypes.find(fileExtension);
 		if (type == contentTypes.end()) {
-			static std::string octetStreamType = "application/octet-stream";
 			return octetStreamType;
 		}
 		return contentTypes[type->second];

--- a/src/core/GetRequestHandler.cpp
+++ b/src/core/GetRequestHandler.cpp
@@ -42,6 +42,72 @@ namespace core {
 		m_streamPosition = 0;
 	}
 
+	const std::string& GetRequestHandler::getMimeType() const {
+		static std::map<std::string, std::string> contentTypes;
+
+		if (contentTypes.empty()) {
+			contentTypes[".aac"] = "audio/aac";
+			contentTypes[".avi"] = "video/x-msvideo";
+			contentTypes[".bin"] = "application/octet-stream";
+			contentTypes[".bmp"] = "image/bmp";
+			contentTypes[".css"] = "text/css";
+			contentTypes[".csv"] = "text/csv";
+			contentTypes[".eot"] = "application/vnd.ms-fontobject";
+			contentTypes[".gz"] = "application/gzip";
+			contentTypes[".gif"] = "image/gif";
+			contentTypes[".htm"] = "text/html";
+			contentTypes[".html"] = "text/html";
+			contentTypes[".ico"] = "image/vnd.microsoft.icon";
+			contentTypes[".jar"] = "application/java-archive";
+			contentTypes[".jpg"] = "image/jpeg";
+			contentTypes[".jpeg"] = "image/jpeg";
+			contentTypes[".js"] = "application/javascript";
+			contentTypes[".json"] = "application/json";
+			contentTypes[".jsonld"] = "application/ld+json";
+			contentTypes[".mjs"] = "text/javascript";
+			contentTypes[".mp3"] = "audio/mpeg";
+			contentTypes[".mp4"] = "video/mp4";
+			contentTypes[".mpeg"] = "video/mpeg";
+			contentTypes[".oga"] = "audio/ogg";
+			contentTypes[".ogg"] = "audio/opus";
+			contentTypes[".ogv"] = "video/ogg";
+			contentTypes[".ogx"] = "application/ogg";
+			contentTypes[".opus"] = "audio/ogg";
+			contentTypes[".otf"] = "font/otf";
+			contentTypes[".pdf"] = "application/pdf";
+			contentTypes[".php"] = "application/x-httpd-php";
+			contentTypes[".png"] = "image/png";
+			contentTypes[".rar"] = "application/vnd.rar";
+			contentTypes[".rtf"] = "application/rtf";
+			contentTypes[".sh"] = "application/x-sh";
+			contentTypes[".svg"] = "image/svg+xml";
+			contentTypes[".tar"] = "application/x-tar";
+			contentTypes[".tif"] = "image/tiff";
+			contentTypes[".tiff"] = "image/tiff";
+			contentTypes[".ttf"] = "font/ttf";
+			contentTypes[".txt"] = "text/plain";
+			contentTypes[".wav"] = "audio/wav";
+			contentTypes[".webm"] = "video/webm";
+			contentTypes[".webp"] = "image/webp";
+			contentTypes[".xhtml"] = "application/xhtml+xml";
+			contentTypes[".xml"] = "application/xml";
+			contentTypes[".zip"] = "application/zip";
+			contentTypes[".7z"] = "application/x-7z-compressed";
+		}
+
+		std::string fileExtension = m_filePath.substr(m_filePath.rfind('.'));
+		if (fileExtension.find('/') != std::string::npos) {
+			static std::string htmlType = "text/html";
+			return htmlType;
+		}
+		std::map<std::string, std::string>::iterator type = contentTypes.find(fileExtension);
+		if (type == contentTypes.end()) {
+			static std::string octetStreamType = "application/octet-stream";
+			return octetStreamType;
+		}
+		return contentTypes[type->second];
+	}
+
 	// todo: make sure path exists, file exists, can access, etc. etc.
 	// F_OK, R_OK, probably?
 	// throw correct status code if any issues arise
@@ -107,6 +173,7 @@ namespace core {
 	void GetRequestHandler::generateAutoindexResponse(const http::Request& request, http::Response& response) {
 		response.appendBody(generateDirectoryListing(request, m_route.absoluteFilePath));
 		response.setStatusCode(http::OK);
+		response.setHeader("Content-Type", "text/html");
 	}
 
 	void GetRequestHandler::selectFile() {
@@ -165,6 +232,7 @@ namespace core {
 					generateAutoindexResponse(request, response);
 					m_state = DONE;
 				} else {
+					response.setHeader("Content-Type", getMimeType());
 					m_state = PROCESS;
 				}
 				return true;

--- a/src/core/RequestProcessor.cpp
+++ b/src/core/RequestProcessor.cpp
@@ -199,11 +199,9 @@ namespace core {
 		}
 		m_response->setHeader("Connection", "close");
 		m_response->appendBody(response);
+		m_response->setHeader("Content-Type", "text/html");
 	}
 
-	// todo: remove body
-	// todo: check if appendHeader works instead of constructing
-	//       temporary locationHeader vector
 	void RequestProcessor::generateRedirectResponse() {
 		const Route& route = m_router.getResult();
 


### PR DESCRIPTION
### Description

This PR includes mime-types for GET responses. Most common file types are supported.

This allows clients to use specific methods of displaying certain file types, e.g. the PDF viewer or media player.

### Type of Change

- [x] New feature

### How to Test

GET a file with a supported file type.

Closes #90 