### PR TITLE
refactor(config): configure limits globally

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -1,43 +1,47 @@
-server {
-	listen 127.0.0.1:8081;
-	server_name cool-server.com;
-
-	root /www;
-	data_dir /workspaces/webserv;
-	autoindex on;
-	index index.html;
-
+http {
 	client_max_body_size 10485760; # 10 MB
 	max_header_value_length 8192; # 8 KB
 	max_header_count 128;
 	max_header_value_count 64;
 	max_header_name_length 256;
 	max_uri_length 256;
-	# connection_timeout 60; # timeout in seconds
-	# cgi_timeout 60; # cgi script timeout in seconds
-	#error_page 404 404.html;
-	#cgi_interpreter .py /bin/python3;
+	data_dir /workspaces/webserv;
+	cgi_interpreter .py /bin/python3;
+	cgi_interpreter .sh /bin/bash;
+	connection_timeout 60; # timeout in seconds
+	cgi_timeout 60; # cgi script timeout in seconds
 
-	# todo: PATHS TO VALIDATE AGAINST CONTAINING RELATIVE PATH (/.. or /. segments)
-	# root, data_dir, location, index (should only be files), return
-	# todo: check if settings apply to children
+	server {
+		listen 127.0.0.1:8081;
+		server_name cool-server.com;
 
-	limit_except GET POST DELETE; #todo: check if applies to locations
-
-	location /images {
-		root /images;
-		limit_except GET POST DELETE;
+		root /www;
+		autoindex on;
 		index index.html;
-		
-		upload_dir /uploads;
 
-		location /cats {
-			root /cats;
-			autoindex on;
+		#error_page 404 404.html;
+
+		# todo: PATHS TO VALIDATE AGAINST CONTAINING RELATIVE PATH (/.. or /. segments)
+		# root, data_dir, location, index (should only be files), return
+		# todo: check if settings apply to children
+		limit_except GET POST DELETE; #todo: check if applies to locations
+
+		location /images {
+			root /images;
+			limit_except GET POST DELETE;
+			index index.html;
+
+			upload_dir /uploads;
+
+			location /cats {
+				root /cats;
+				autoindex on;
+			}
+		}
+
+		location /old-route {
+			return 301 /images;
 		}
 	}
 
-	location /old-route {
-		return 301 /images;
-	}
 }

--- a/include/config/Config.hpp
+++ b/include/config/Config.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "config/HttpConfig.hpp"
+#include "config/ServerConfig.hpp"
+
+#include <map>
+#include <vector>
+
+namespace config {
+
+	class Config {
+		public:
+			typedef std::vector<ServerConfig> ServerConfigs;
+			typedef std::map<std::string /*address*/, ServerConfigs> ListenServerConfigs;
+
+			HttpConfig globalConfig;
+			ListenServerConfigs listenServerConfigs;
+			std::vector<ServerConfig> serverConfigs;
+
+		private:
+	};
+
+} /* namespace config */

--- a/include/config/HttpConfig.hpp
+++ b/include/config/HttpConfig.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <map>
+#include <string>
+
+namespace config {
+
+	struct HttpConfig {
+		public:
+			unsigned long maxBodySize;
+			unsigned long maxHeaderValueLength;
+			unsigned long maxHeaderCount;
+			unsigned long maxHeaderValueCount;
+			unsigned long maxHeaderNameLength;
+			unsigned long connectionTimeout;
+			unsigned long cgiTimeout;
+			unsigned long maxUriLength;
+			std::string dataDirectory;
+			std::map<std::string, std::string> cgiInterpreters;
+
+			HttpConfig();
+			~HttpConfig();
+			HttpConfig(const HttpConfig& other);
+			HttpConfig& operator=(const HttpConfig& rhs);
+
+			void print() const;
+			void validate() const;
+	};
+
+} /* namespace config */

--- a/include/config/ParseException.hpp
+++ b/include/config/ParseException.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdexcept>
+#include <string>
+
+namespace config {
+
+	class ParseException : public std::runtime_error {
+		public:
+			explicit ParseException(const std::string& message);
+			explicit ParseException(std::size_t line, const std::string& message);
+			virtual ~ParseException() throw();
+
+			const std::string& getMessage() const;
+
+		private:
+			std::string m_message;
+	};
+
+} /* namespace config */

--- a/include/config/Parser.hpp
+++ b/include/config/Parser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config/Config.hpp"
+#include "config/ParseException.hpp"
 #include "config/ServerConfig.hpp"
 #include "shared/NonCopyable.hpp"
 #include "shared/stringUtils.hpp"
@@ -7,27 +9,6 @@
 #include <map>
 
 namespace config {
-
-	class parse_exception : public std::runtime_error {
-		public:
-			explicit parse_exception(const std::string& message);
-			explicit parse_exception(std::size_t line, const std::string& message);
-			virtual ~parse_exception() throw();
-
-			const std::string& getMessage() const;
-
-		private:
-			std::string m_message;
-	};
-
-	struct Config {
-			typedef std::vector<ServerConfig> ServerConfigs;
-			typedef std::map<std::string /*address*/, ServerConfigs> ListenServerConfigs;
-
-			HttpConfig globalConfig;
-			ListenServerConfigs listenServerConfigs;
-			std::vector<ServerConfig> serverConfigs;
-	};
 
 	class Parser : shared::mixin::NonCopyable {
 			typedef void (Parser::*LocationTokenParser)(const std::string&, LocationConfig&);
@@ -89,16 +70,16 @@ namespace config {
 			CommandType matchDirective(const std::string& token, const std::map<std::string, CommandType>& expectedDirectives);
 			static void handleSigint(int signum);
 
-			void parseFromData() throw(parse_exception);
-			void processParsedData() throw(parse_exception);
+			void parseFromData() throw(ParseException);
+			void processParsedData() throw(ParseException);
 
-			void expectHttpBlock() throw(parse_exception);
-			void expectServerBlock(const HttpConfig& globalConfig) throw(parse_exception);
-			void expectLocationBlock(LocationConfig& parentLocation) throw(parse_exception);
+			void expectHttpBlock() throw(ParseException);
+			void expectServerBlock(const HttpConfig& globalConfig) throw(ParseException);
+			void expectLocationBlock(LocationConfig& parentLocation) throw(ParseException);
 
-			void processHttpValue(const std::string& key, const std::string& value, CommandType type) throw(parse_exception);
-			void processServerValue(const std::string& key, const std::string& value, CommandType type, ServerConfig& server) throw(parse_exception);
-			void processLocationValue(const std::string& key, const std::string& value, CommandType type, LocationConfig& location) throw(parse_exception);
+			void processHttpValue(const std::string& key, const std::string& value, CommandType type) throw(ParseException);
+			void processServerValue(const std::string& key, const std::string& value, CommandType type, ServerConfig& server) throw(ParseException);
+			void processLocationValue(const std::string& key, const std::string& value, CommandType type, LocationConfig& location) throw(ParseException);
 
 			static const std::map<std::string, CommandType>& httpDirectives();
 			static const std::map<std::string, CommandType>& serverDirectives();
@@ -106,22 +87,22 @@ namespace config {
 
 		private:
 			// ------------------------  generic parsers  ------------------- //
-			void parseIntegerValue(const std::string& key, const std::string& value, unsigned long& destination) throw(parse_exception);
-			void parsePathValue(const std::string& key, const std::string& value, std::string& destination) throw(parse_exception);
+			void parseIntegerValue(const std::string& key, const std::string& value, unsigned long& destination) throw(ParseException);
+			void parsePathValue(const std::string& key, const std::string& value, std::string& destination) throw(ParseException);
 			// ------------------------  server parsers  -------------------- //
-			void parseListen(const std::string& value, ServerConfig& server) throw(parse_exception);
-			void parseServerName(const std::string& value, ServerConfig& server) throw(parse_exception);
-			void parseCGIInterpreter(const std::string& value, HttpConfig& globalConfig) throw(parse_exception);
+			void parseListen(const std::string& value, ServerConfig& server) throw(ParseException);
+			void parseServerName(const std::string& value, ServerConfig& server) throw(ParseException);
+			void parseCGIInterpreter(const std::string& value, HttpConfig& globalConfig) throw(ParseException);
 
-			uint32_t parseIpAddress(const std::string& host) throw(parse_exception);
-			void assignAbsolutePaths(ServerConfig& server, LocationConfig& parentLocation) throw(parse_exception);
+			uint32_t parseIpAddress(const std::string& host) throw(ParseException);
+			void assignAbsolutePaths(ServerConfig& server, LocationConfig& parentLocation) throw(ParseException);
 
 			// ------------------------  location parsers  ------------------ //
-			void parseReturn(const std::string& value, LocationConfig& location) throw(parse_exception);
-			void parseLimitExcept(const std::string& value, LocationConfig& location) throw(parse_exception);
-			void parseIndex(const std::string& value, LocationConfig& location) throw(parse_exception);
-			void parseAutoindex(const std::string& value, LocationConfig& location) throw(parse_exception);
-			void parseErrorPage(const std::string& value, LocationConfig& location) throw(parse_exception);
+			void parseReturn(const std::string& value, LocationConfig& location) throw(ParseException);
+			void parseLimitExcept(const std::string& value, LocationConfig& location) throw(ParseException);
+			void parseIndex(const std::string& value, LocationConfig& location) throw(ParseException);
+			void parseAutoindex(const std::string& value, LocationConfig& location) throw(ParseException);
+			void parseErrorPage(const std::string& value, LocationConfig& location) throw(ParseException);
 	};
 
 } /* namespace config */

--- a/include/config/ServerConfig.hpp
+++ b/include/config/ServerConfig.hpp
@@ -2,10 +2,11 @@
 
 #include <stdint.h>
 
+#include "config/HttpConfig.hpp"
 #include "config/LocationConfig.hpp"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace config {
 
@@ -14,26 +15,14 @@ namespace config {
 			int port;
 			uint32_t ipAddress;
 			std::string socketAddress;
-			unsigned long maxBodySize;
-			unsigned long maxHeaderValueLength;
-			unsigned long maxHeaderCount;
-			unsigned long maxHeaderValueCount;
-			unsigned long maxHeaderNameLength;
-			unsigned long connectionTimeout;
-			unsigned long cgiTimeout;
-			unsigned long maxUriLength;
-			std::map<std::string, std::string> cgiInterpreters;
-			std::string dataDirectory;
 			std::vector<std::string> serverNames;
 			LocationConfig location;
+			const HttpConfig& global;
 
-			ServerConfig();
+			explicit ServerConfig(const HttpConfig& globalConfig);
 			~ServerConfig();
 			ServerConfig(const ServerConfig& other);
 			const ServerConfig& operator=(const ServerConfig& rhs);
-
-			bool hasRoot() const;
-			bool hasDataDir() const;
 
 			void validate() const;
 			void print() const;

--- a/include/core/CGIEventHandler.hpp
+++ b/include/core/CGIEventHandler.hpp
@@ -8,7 +8,7 @@ namespace core {
 
 	class CGIEventHandler : public io::IEventHandler {
 		public:
-			explicit CGIEventHandler(CGIProcessor& processor, const http::Request& request, http::Response*& response, const config::ServerConfig& serverConfig);
+			explicit CGIEventHandler(CGIProcessor& processor, const http::Request& request, http::Response*& response, const config::HttpConfig& httpConfig);
 			~CGIEventHandler();
 
 			io::EventResult onReadable(int32_t fd);

--- a/include/core/CGIProcessor.hpp
+++ b/include/core/CGIProcessor.hpp
@@ -15,7 +15,7 @@ namespace core {
 
 	class CGIProcessor : shared::mixin::NonCopyable {
 		public:
-			explicit CGIProcessor(io::Dispatcher& dispatcher, const config::ServerConfig& serverConfig = config::ServerConfig());
+			explicit CGIProcessor(io::Dispatcher& dispatcher, const config::ServerConfig& serverConfig);
 			~CGIProcessor();
 
 			bool process(const http::Request& request);

--- a/include/core/Reactor.hpp
+++ b/include/core/Reactor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config/Parser.hpp"
+#include "config/Config.hpp"
 #include "io/Dispatcher.hpp"
 #include "shared/NonCopyable.hpp"
 

--- a/include/core/RequestProcessor.hpp
+++ b/include/core/RequestProcessor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config/Parser.hpp"
+#include "config/Config.hpp"
 #include "config/ServerConfig.hpp"
 #include "core/CGIProcessor.hpp"
 #include "core/Router.hpp"

--- a/include/core/VirtualServer.hpp
+++ b/include/core/VirtualServer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "config/Parser.hpp"
+#include "config/Config.hpp"
+#include "config/ServerConfig.hpp"
 #include "core/Connection.hpp"
 #include "io/Socket.hpp"
 #include "shared/NonCopyable.hpp"

--- a/include/http/AMessageParser.hpp
+++ b/include/http/AMessageParser.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config/ServerConfig.hpp"
+#include "config/HttpConfig.hpp"
 #include "http/http.hpp"
 #include "shared/Buffer.hpp"
 #include "shared/NonCopyable.hpp"
@@ -22,7 +22,7 @@ namespace http {
 			std::size_t maxHeaderNameLength;
 
 			MessageParserConfig();
-			explicit MessageParserConfig(const config::ServerConfig& serverConfig);
+			explicit MessageParserConfig(const config::HttpConfig& httpConfig);
 	};
 
 	class AMessage;

--- a/include/http/RequestParser.hpp
+++ b/include/http/RequestParser.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config/ServerConfig.hpp"
+#include "config/HttpConfig.hpp"
 #include "http/AMessageParser.hpp"
 #include "http/http.hpp"
 
@@ -10,7 +10,7 @@ namespace http {
 			MessageParserConfig messageParserConfig;
 			std::size_t maxUriLength;
 			RequestParserConfig();
-			explicit RequestParserConfig(const config::ServerConfig& serverConfig);
+			explicit RequestParserConfig(const config::HttpConfig& httpConfig);
 	};
 
 	class Request;

--- a/include/http/ResponseParser.hpp
+++ b/include/http/ResponseParser.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config/ServerConfig.hpp"
+#include "config/HttpConfig.hpp"
 #include "http/AMessageParser.hpp"
 #include "http/http.hpp"
 
@@ -10,7 +10,7 @@ namespace http {
 			MessageParserConfig messageParserConfig;
 			std::size_t maxReasonPhraseLength;
 			ResponseParserConfig();
-			explicit ResponseParserConfig(const config::ServerConfig& serverConfig);
+			explicit ResponseParserConfig(const config::HttpConfig& httpConfig);
 	};
 
 	class Response;

--- a/src/config/HttpConfig.cpp
+++ b/src/config/HttpConfig.cpp
@@ -1,6 +1,6 @@
 #include "config/HttpConfig.hpp"
 
-#include "config/Parser.hpp" // todo: PLEASE MOVE CONFIG AND EXCEPTION TO SEPARATE FILES
+#include "config/ParseException.hpp"
 
 #include <iostream>
 
@@ -70,7 +70,7 @@ namespace config {
 
 	void HttpConfig::validate() const {
 		if (dataDirectory.empty()) {
-			throw parse_exception("HTTP block requires a 'data_dir'");
+			throw ParseException("HTTP block requires a 'data_dir'");
 		}
 	}
 

--- a/src/config/HttpConfig.cpp
+++ b/src/config/HttpConfig.cpp
@@ -1,0 +1,77 @@
+#include "config/HttpConfig.hpp"
+
+#include "config/Parser.hpp" // todo: PLEASE MOVE CONFIG AND EXCEPTION TO SEPARATE FILES
+
+#include <iostream>
+
+namespace config {
+
+	HttpConfig::HttpConfig()
+		: maxBodySize(10 * 1024 * 1024)	 // 10MB
+		, maxHeaderValueLength(8 * 1024) // 8KB
+		, maxHeaderCount(128)			 // 128 headers
+		, maxHeaderValueCount(64)		 // 64 values
+		, maxHeaderNameLength(256)		 // 256B
+		, connectionTimeout(60)
+		, cgiTimeout(60)
+		, maxUriLength(1024)
+		, dataDirectory("")
+		, cgiInterpreters() {}
+
+	HttpConfig::~HttpConfig() {}
+
+	HttpConfig::HttpConfig(const HttpConfig& other)
+		: maxBodySize(other.maxBodySize)
+		, maxHeaderValueLength(other.maxHeaderValueLength)
+		, maxHeaderCount(other.maxHeaderCount)
+		, maxHeaderValueCount(other.maxHeaderValueCount)
+		, maxHeaderNameLength(other.maxHeaderNameLength)
+		, connectionTimeout(other.connectionTimeout)
+		, cgiTimeout(other.cgiTimeout)
+		, maxUriLength(other.maxUriLength)
+		, dataDirectory(other.dataDirectory)
+		, cgiInterpreters(other.cgiInterpreters) {}
+
+	HttpConfig& HttpConfig::operator=(const HttpConfig& rhs) {
+		if (this == &rhs) {
+			return *this;
+		}
+		maxBodySize = rhs.maxBodySize;
+		maxHeaderCount = rhs.maxHeaderCount;
+		maxHeaderNameLength = rhs.maxHeaderNameLength;
+		maxHeaderValueCount = rhs.maxHeaderValueCount;
+		maxHeaderValueLength = rhs.maxHeaderValueLength;
+		connectionTimeout = rhs.connectionTimeout;
+		cgiTimeout = rhs.cgiTimeout;
+		maxUriLength = rhs.maxUriLength;
+		dataDirectory = rhs.dataDirectory;
+		cgiInterpreters = rhs.cgiInterpreters;
+		return *this;
+	}
+
+	void HttpConfig::print() const {
+		std::cout << "-------- Http Config: --------" << std::endl;
+
+		std::cout << "MaxBodySize: " << maxBodySize << std::endl;
+		std::cout << "MaxHeaderCount: " << maxHeaderCount << std::endl;
+		std::cout << "MaxHeaderNameLength: " << maxHeaderNameLength << std::endl;
+		std::cout << "MaxHeaderValueCount: " << maxHeaderValueCount << std::endl;
+		std::cout << "MaxHeadeaValueLength: " << maxHeaderValueLength << std::endl;
+		std::cout << "ConnectionTimeout: " << connectionTimeout << std::endl;
+		std::cout << "cgiTimeout: " << cgiTimeout << std::endl;
+		std::cout << "maxUriLength: " << maxUriLength << std::endl;
+		std::cout << "dataDirectory: " << dataDirectory << std::endl;
+		for (std::map<std::string, std::string>::const_iterator interpreter = cgiInterpreters.begin(); interpreter != cgiInterpreters.end(); ++interpreter) {
+			std::cout << interpreter->first << " => " << interpreter->second << std::endl;
+		}
+
+		std::cout << "--------------------------------" << std::endl;
+	}
+
+	void HttpConfig::validate() const {
+		if (dataDirectory.empty()) {
+			throw parse_exception("HTTP block requires a 'data_dir'");
+		}
+	}
+
+} /* namespace config */

--- a/src/config/LocationConfig.cpp
+++ b/src/config/LocationConfig.cpp
@@ -1,6 +1,6 @@
 #include "config/LocationConfig.hpp"
 
-#include "config/Parser.hpp" //hm
+#include "config/ParseException.hpp"
 
 #include <iostream>
 
@@ -73,7 +73,7 @@ namespace config {
 	// TODO: implement
 	void LocationConfig::validate() const {
 		if (path.empty()) {
-			throw parse_exception("LocationConfig doesn't have a path");
+			throw ParseException("LocationConfig doesn't have a path");
 		}
 	}
 

--- a/src/config/ParseException.cpp
+++ b/src/config/ParseException.cpp
@@ -1,0 +1,20 @@
+#include "config/ParseException.hpp"
+
+#include "shared/stringUtils.hpp"
+
+namespace config {
+
+	ParseException::ParseException(const std::string& message)
+		: std::runtime_error("Parsing failed: " + message)
+		, m_message("Parsing failed: " + message) {}
+
+	ParseException::ParseException(std::size_t line, const std::string& message)
+		: std::runtime_error("Line " + shared::string::toString(line) + ": Parsing failed: " + message)
+		, m_message("Line " + shared::string::toString(line) + ": Parsing failed: " + message) {}
+
+	ParseException::~ParseException() throw() {}
+
+	const std::string& ParseException::getMessage() const { return m_message; }
+
+
+} /* namespace config */

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -6,21 +6,12 @@
 
 namespace config {
 
-	ServerConfig::ServerConfig()
+	ServerConfig::ServerConfig(const HttpConfig& globalConfig)
 		: port(8080)
 		, ipAddress(LOCALHOST_ADDRESS)
-		, maxBodySize(10 * 1024 * 1024)	 // 10MB
-		, maxHeaderValueLength(8 * 1024) // 8KB
-		, maxHeaderCount(128)			 // 128 headers
-		, maxHeaderValueCount(64)		 // 64 values
-		, maxHeaderNameLength(256)		 // 256B
-		, connectionTimeout(60)
-		, cgiTimeout(60)
-		, maxUriLength(1024)
-		, cgiInterpreters()
-		, dataDirectory("")
 		, serverNames()
-		, location() {}
+		, location()
+		, global(globalConfig) {}
 
 	ServerConfig::~ServerConfig() {}
 
@@ -28,18 +19,9 @@ namespace config {
 		: port(other.port)
 		, ipAddress(other.ipAddress)
 		, socketAddress(other.socketAddress)
-		, maxBodySize(other.maxBodySize)
-		, maxHeaderValueLength(other.maxHeaderValueLength)
-		, maxHeaderCount(other.maxHeaderCount)
-		, maxHeaderValueCount(other.maxHeaderValueCount)
-		, maxHeaderNameLength(other.maxHeaderNameLength)
-		, connectionTimeout(other.connectionTimeout)
-		, cgiTimeout(other.cgiTimeout)
-		, maxUriLength(other.maxUriLength)
-		, cgiInterpreters(other.cgiInterpreters)
-		, dataDirectory(other.dataDirectory)
 		, serverNames(other.serverNames)
-		, location(other.location) {}
+		, location(other.location)
+		, global(other.global) {}
 
 	const ServerConfig& ServerConfig::operator=(const ServerConfig& rhs) {
 		if (this == &rhs) {
@@ -48,33 +30,16 @@ namespace config {
 		port = rhs.port;
 		ipAddress = rhs.ipAddress;
 		socketAddress = rhs.socketAddress;
-		maxBodySize = rhs.maxBodySize;
-		maxHeaderCount = rhs.maxHeaderCount;
-		maxHeaderNameLength = rhs.maxHeaderNameLength;
-		maxHeaderValueCount = rhs.maxHeaderValueCount;
-		maxHeaderValueLength = rhs.maxHeaderValueLength;
-		connectionTimeout = rhs.connectionTimeout;
-		cgiTimeout = rhs.cgiTimeout;
-		maxUriLength = rhs.maxUriLength;
-		cgiInterpreters = rhs.cgiInterpreters;
-		dataDirectory = rhs.dataDirectory;
 		serverNames = rhs.serverNames;
 		location = rhs.location;
 		return *this;
 	}
-
-	bool ServerConfig::hasRoot() const { return !location.root.empty(); }
-
-	bool ServerConfig::hasDataDir() const { return !dataDirectory.empty(); }
 
 	/**
 	 * @brief Validate the server, ensuring it has all mandatory keys
 	 * and that nothing else fucky wucky is going on
 	 */
 	void ServerConfig::validate() const {
-		if (dataDirectory.empty()) {
-			throw parse_exception("Server requires a 'data_dir'");
-		}
 		if (location.root.empty()) {
 			throw parse_exception("Server requires a 'root'");
 		}
@@ -86,15 +51,7 @@ namespace config {
 
 		std::cout << "Port: " << port << std::endl;
 		std::cout << "IPAddress: " << ipAddress << std::endl;
-		std::cout << "MaxBodySize: " << maxBodySize << std::endl;
-		std::cout << "DataDirectory: " << dataDirectory << std::endl;
 		std::cout << "cgiInterpreters:" << std::endl;
-		for (std::map<std::string, std::string>::const_iterator interpreter = cgiInterpreters.begin(); interpreter != cgiInterpreters.end(); ++interpreter) {
-			std::cout << interpreter->first << " => " << interpreter->second << std::endl;
-		}
-		std::cout << "ConnectionTimeout: " << connectionTimeout << std::endl;
-		std::cout << "cgiTimeout: " << cgiTimeout << std::endl;
-		std::cout << "maxUriLength: " << maxUriLength << std::endl;
 		std::cout << "Names: ";
 		for (std::vector<std::string>::const_iterator it = serverNames.begin(); it != serverNames.end(); ++it) {
 			std::cout << *it << " ";

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -1,6 +1,6 @@
 #include "config/ServerConfig.hpp"
 
-#include "config/Parser.hpp"
+#include "config/ParseException.hpp"
 
 #include <iostream>
 
@@ -41,7 +41,7 @@ namespace config {
 	 */
 	void ServerConfig::validate() const {
 		if (location.root.empty()) {
-			throw parse_exception("Server requires a 'root'");
+			throw ParseException("Server requires a 'root'");
 		}
 		// TODO: ensure this path exists and can be accessed
 	}

--- a/src/core/CGIEventHandler.cpp
+++ b/src/core/CGIEventHandler.cpp
@@ -1,6 +1,6 @@
 #include "core/CGIEventHandler.hpp"
 
-#include "config/ServerConfig.hpp"
+#include "config/HttpConfig.hpp"
 #include "http/Request.hpp"
 #include "http/Response.hpp"
 #include "shared/Logger.hpp"
@@ -10,13 +10,13 @@
 
 namespace core {
 
-	CGIEventHandler::CGIEventHandler(CGIProcessor& processor, const http::Request& request, http::Response*& response, const config::ServerConfig& serverConfig)
+	CGIEventHandler::CGIEventHandler(CGIProcessor& processor, const http::Request& request, http::Response*& response, const config::HttpConfig& httpConfig)
 		: m_processor(processor)
 		, m_request(request)
 		, m_response(response)
 		, m_totalBytesWritten(0)
 		, m_responseParser() {
-		http::ResponseParserConfig conf(serverConfig);
+		http::ResponseParserConfig conf(httpConfig);
 		conf.messageParserConfig.requireCR = false;
 		conf.messageParserConfig.requireStartLine = false;
 		conf.messageParserConfig.parseBodyWithoutContentLength = true; // I hate this

--- a/src/core/CGIProcessor.cpp
+++ b/src/core/CGIProcessor.cpp
@@ -133,7 +133,7 @@ namespace core {
 					const_cast<char*>(m_scriptName.c_str()),
 					NULL};
 
-				if (chdir((m_serverConfig.dataDirectory + "/cgi-bin").c_str()) == -1) {
+				if (chdir((m_serverConfig.global.dataDirectory + "/cgi-bin").c_str()) == -1) {
 					throw std::runtime_error("chdir() failed: " + std::string(std::strerror(errno)));
 				}
 
@@ -151,11 +151,11 @@ namespace core {
 			m_outputPipe.closeWriteEnd();
 
 			m_dispatcher.registerHandler(m_outputPipe.getReadFd(),
-										 new CGIEventHandler(*this, request, m_response, m_serverConfig),
+										 new CGIEventHandler(*this, request, m_response, m_serverConfig.global),
 										 io::AMultiplexer::EVENT_READ | io::AMultiplexer::EVENT_ERROR | io::AMultiplexer::EVENT_HANGUP);
 			if (request.getMethod() == http::POST) {
 				m_dispatcher.registerHandler(m_inputPipe.getWriteFd(),
-											 new CGIEventHandler(*this, request, m_response, m_serverConfig),
+											 new CGIEventHandler(*this, request, m_response, m_serverConfig.global),
 											 io::AMultiplexer::EVENT_WRITE | io::AMultiplexer::EVENT_ERROR | io::AMultiplexer::EVENT_HANGUP);
 			} else {
 				notifyIOWriteCompletion();

--- a/src/http/AMessageParser.cpp
+++ b/src/http/AMessageParser.cpp
@@ -22,15 +22,15 @@ namespace http {
 		, maxHeaderNameLength(256)		 // 256B
 	{}
 
-	MessageParserConfig::MessageParserConfig(const config::ServerConfig& serverConfig)
+	MessageParserConfig::MessageParserConfig(const config::HttpConfig& httpConfig)
 		: requireCR(true)
 		, requireStartLine(true)
 		, parseBodyWithoutContentLength(false)
-		, maxBodySize(serverConfig.maxBodySize)
-		, maxHeaderValueLength(serverConfig.maxHeaderValueLength)
-		, maxHeaderCount(serverConfig.maxHeaderCount)
-		, maxHeaderValueCount(serverConfig.maxHeaderValueCount)
-		, maxHeaderNameLength(serverConfig.maxHeaderNameLength) {
+		, maxBodySize(httpConfig.maxBodySize)
+		, maxHeaderValueLength(httpConfig.maxHeaderValueLength)
+		, maxHeaderCount(httpConfig.maxHeaderCount)
+		, maxHeaderValueCount(httpConfig.maxHeaderValueCount)
+		, maxHeaderNameLength(httpConfig.maxHeaderNameLength) {
 	}
 
 	const shared::string::StringView AMessageParser::CRLF = shared::string::StringView("\r\n");

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -13,9 +13,9 @@ namespace http {
 		, maxUriLength(1024) // 1KB
 	{}
 
-	RequestParserConfig::RequestParserConfig(const config::ServerConfig& serverConfig)
-		: messageParserConfig(serverConfig)
-		, maxUriLength(1024) {} // todo: set maxUriLength from server config
+	RequestParserConfig::RequestParserConfig(const config::HttpConfig& httpConfig)
+		: messageParserConfig(httpConfig)
+		, maxUriLength(httpConfig.maxUriLength) {}
 
 	RequestParser::RequestParser(const RequestParserConfig& conf)
 		: AMessageParser(conf.messageParserConfig)

--- a/src/http/ResponseParser.cpp
+++ b/src/http/ResponseParser.cpp
@@ -9,8 +9,8 @@ namespace http {
 		: messageParserConfig() // 1KB
 		, maxReasonPhraseLength(1024) {}
 
-	ResponseParserConfig::ResponseParserConfig(const config::ServerConfig& serverConfig)
-		: messageParserConfig(serverConfig)
+	ResponseParserConfig::ResponseParserConfig(const config::HttpConfig& httpConfig)
+		: messageParserConfig(httpConfig)
 		, maxReasonPhraseLength(1024) {}
 
 	ResponseParser::ResponseParser(const ResponseParserConfig& conf)


### PR DESCRIPTION
This PR includes changes to the config parser and the ServerConfig class, moving all limits, `data_dir` as well as `cgi_interpreter` to a single new global `HttpConfig`, accessible via `ServerConfig.global`.

Closes #93 