### PR TITLE
fix: recover from bad_alloc

### DIFF
--- a/src/io/Dispatcher.cpp
+++ b/src/io/Dispatcher.cpp
@@ -48,6 +48,10 @@ namespace io {
 	}
 
 	int32_t Dispatcher::dispatch(int32_t timeoutMs) {
+		if (m_handlers.empty()) {
+			throw std::runtime_error("no handlers registered for dispatching");
+		}
+
 		int32_t numEvents = m_multiplexer.poll(timeoutMs);
 
 		const AMultiplexer::Events& events = m_multiplexer.getReadyEvents();
@@ -94,8 +98,6 @@ namespace io {
 			if (result == UNREGISTER) {
 				secureUnregisterHandler(event.fd);
 			}
-		} catch (const std::bad_alloc&) {
-			throw;
 		} catch (const std::exception& e) {
 			LOG_ERROR("handler failed for fd " + shared::string::toString(event.fd) + ": " + e.what());
 			secureUnregisterHandler(event.fd);


### PR DESCRIPTION
This pr makes sure that we never quit the program as stated in the subject.
The new strategy for malloc failure is basically to drop each handler (connection or server) where the bad_alloc exception occurred which should free up some memory.
if we have no server listening anymore we terminate the program.
Maybe its odd that we also drop servers but it is anyways way more likely that we run out of mem in the connection handler.
we could try to re register the failed server again but I think it is alright like this because we would log anyways that a server shut dow.