### PR TITLE
fix(requestParser): decode & encode URIs

### DIFF
--- a/include/core/GetRequestHandler.hpp
+++ b/include/core/GetRequestHandler.hpp
@@ -28,6 +28,8 @@ namespace core {
 			std::string generateDirectoryListing(const http::Request& request, const std::string& filePath);
 			const std::string& getMimeType() const;
 
+			std::string hexEncode(const std::string& str);
+
 		private:
 			static const std::streamsize BUFFER_SIZE = 16384; // 16 KB
 

--- a/include/http/RequestParser.hpp
+++ b/include/http/RequestParser.hpp
@@ -31,8 +31,13 @@ namespace http {
 			virtual ParseResult parseStartLine();
 			void parseUriOriginForm(const shared::string::StringView& uriView);
 			void parseUriAbsoluteForm(const shared::string::StringView& uriView);
+			void decodeUri(class Uri& uri);
 			void parsePath();
 			std::string normalizePath(const std::string& path);
+
+			static bool isHexadecimal(char c);
+			static char hexToChar(char left, char right);
+			static std::string decodeHexEncoded(const std::string& str);
 
 			virtual void interpretHeaders();
 


### PR DESCRIPTION
This PR includes URL en- and decoding in a few places:
- decode all incoming URIs (in statusLines)
- encode URIs for Directory Index response